### PR TITLE
fix: EC2 ECSでcanary-serviceのhealth checkが通らない #19

### DIFF
--- a/rollout.go
+++ b/rollout.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
-	"regexp"
 	"time"
 )
 
@@ -142,10 +141,14 @@ func (envars *Envars) EnsureTaskHealthy(
 				}
 			}
 		} else if *launchType == "EC2" {
-			instanceArn := o.Tasks[0].ContainerInstanceArn
-			r := regexp.MustCompile(":container-instance/(.+)$")
-			instanceId := r.FindStringSubmatch(*instanceArn)[1]
-			canaryTaskId = &instanceId
+			containerInstanceArn := o.Tasks[0].ContainerInstanceArn
+			if outputs, err := ctx.Ecs.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+				ContainerInstances: []*string{containerInstanceArn},
+			}); err != nil {
+				return err
+			} else {
+				canaryTaskId = outputs.ContainerInstances[0].Ec2InstanceId
+			}
 		} else {
 			errMsg := fmt.Sprintf("launch type is unknown (%s)", *launchType)
 			log.Error(errMsg)

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -45,6 +45,7 @@ func (envars *Envars) Setup(ctrl *gomock.Controller, currentTaskCount int64, lau
 	ecsMock.EXPECT().WaitUntilTasksRunning(gomock.Any()).DoAndReturn(mocker.WaitUntilTasksRunning).AnyTimes()
 	ecsMock.EXPECT().WaitUntilTasksStopped(gomock.Any()).DoAndReturn(mocker.WaitUntilTasksStopped).AnyTimes()
 	ecsMock.EXPECT().ListTasks(gomock.Any()).DoAndReturn(mocker.ListTasks).AnyTimes()
+	ecsMock.EXPECT().DescribeContainerInstances(gomock.Any()).DoAndReturn(mocker.DescribeContainerInstances).AnyTimes()
 	albMock.EXPECT().DescribeTargetGroups(gomock.Any()).DoAndReturn(mocker.DescribeTargetGroups).AnyTimes()
 	albMock.EXPECT().DescribeTargetHealth(gomock.Any()).DoAndReturn(mocker.DescribeTargetHealth).AnyTimes()
 	albMock.EXPECT().DescribeTargetGroupAttributes(gomock.Any()).DoAndReturn(mocker.DescribeTargetGroupAttibutes).AnyTimes()

--- a/test/context.go
+++ b/test/context.go
@@ -84,8 +84,8 @@ func (ctx *MockContext) CreateService(input *ecs.CreateServiceInput) (*ecs.Creat
 		DesiredCount:                  input.DesiredCount,
 		TaskDefinition:                input.TaskDefinition,
 		HealthCheckGracePeriodSeconds: aws.Int64(0),
-		Status:     &st,
-		ServiceArn: &idstr,
+		Status:                        &st,
+		ServiceArn:                    &idstr,
 	}
 	ctx.mux.Lock()
 	ctx.Services[*input.ServiceName] = ret
@@ -317,6 +317,19 @@ func (ctx *MockContext) DescribeTasks(input *ecs.DescribeTasksInput) (*ecs.Descr
 	}
 	return &ecs.DescribeTasksOutput{
 		Tasks: ret,
+	}, nil
+}
+func (ctx *MockContext) DescribeContainerInstances(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error) {
+	ctx.mux.Lock()
+	defer ctx.mux.Unlock()
+	var ret []*ecs.ContainerInstance
+	ec2Id := "i-1234567890abcdefg"
+	instance := ecs.ContainerInstance{
+		Ec2InstanceId: &ec2Id,
+	}
+	ret = append(ret, &instance)
+	return &ecs.DescribeContainerInstancesOutput{
+		ContainerInstances: ret,
 	}, nil
 }
 


### PR DESCRIPTION
close #19 

コンテナインスタンスIDではなく、EC2インスタンスIDを使う必要がありました。