### PR TITLE
EC2 ECSのcanary-service作成時にタスク配置制約を適用するようにした

### DIFF
--- a/cli/cage/commands/rollout.go
+++ b/cli/cage/commands/rollout.go
@@ -55,10 +55,16 @@ func RollOutCommand() cli.Command {
 				Destination: dest.Service,
 			},
 			cli.StringFlag{
-				Name: "canaryService",
-				EnvVar: cage.CanaryServiceKey,
-				Usage: "canary service name",
+				Name:        "canaryService",
+				EnvVar:      cage.CanaryServiceKey,
+				Usage:       "canary service name",
 				Destination: dest.CanaryService,
+			},
+			cli.StringFlag{
+				Name:        "canaryInstanceId",
+				EnvVar:      cage.CanaryInstanceIdKey,
+				Usage:       "canary instance id (required only EC2 ECS)",
+				Destination: dest.CanaryInstanceId,
 			},
 			cli.StringFlag{
 				Name:        "serviceDefinitionBase64",

--- a/cli/cage/commands/rollout.go
+++ b/cli/cage/commands/rollout.go
@@ -61,10 +61,10 @@ func RollOutCommand() cli.Command {
 				Destination: dest.CanaryService,
 			},
 			cli.StringFlag{
-				Name:        "canaryInstanceId",
-				EnvVar:      cage.CanaryInstanceIdKey,
-				Usage:       "canary instance id (required only EC2 ECS)",
-				Destination: dest.CanaryInstanceId,
+				Name:        "canaryInstanceArn",
+				EnvVar:      cage.CanaryInstanceArnKey,
+				Usage:       "canary instance ARN (required only EC2 ECS)",
+				Destination: dest.CanaryInstanceArn,
 			},
 			cli.StringFlag{
 				Name:        "serviceDefinitionBase64",

--- a/env.go
+++ b/env.go
@@ -16,7 +16,7 @@ type Envars struct {
 	Cluster                 *string  `json:"cluster" type:"string" required:"true"`
 	Service                 *string  `json:"service" type:"string" required:"true"`
 	CanaryService           *string
-	CanaryInstanceId        *string
+	CanaryInstanceArn       *string
 	TaskDefinitionBase64    *string `json:"nextTaskDefinitionBase64" type:"string"`
 	TaskDefinitionArn       *string `json:"nextTaskDefinitionArn" type:"string"`
 	ServiceDefinitionBase64 *string
@@ -34,7 +34,7 @@ const kDefaultRegion = "us-west-2"
 
 // optional
 const CanaryServiceKey = "CAGE_CANARY_SERVICE"
-const CanaryInstanceIdKey = "CAGE_CANARY_INSTANCE_ID"
+const CanaryInstanceArnKey = "CAGE_CANARY_INSTANCE_ARN"
 const RegionKey = "CAGE_REGION"
 
 func isEmpty(o *string) bool {

--- a/env.go
+++ b/env.go
@@ -16,6 +16,7 @@ type Envars struct {
 	Cluster                 *string  `json:"cluster" type:"string" required:"true"`
 	Service                 *string  `json:"service" type:"string" required:"true"`
 	CanaryService           *string
+	CanaryInstanceId        *string
 	TaskDefinitionBase64    *string `json:"nextTaskDefinitionBase64" type:"string"`
 	TaskDefinitionArn       *string `json:"nextTaskDefinitionArn" type:"string"`
 	ServiceDefinitionBase64 *string
@@ -33,6 +34,7 @@ const kDefaultRegion = "us-west-2"
 
 // optional
 const CanaryServiceKey = "CAGE_CANARY_SERVICE"
+const CanaryInstanceIdKey = "CAGE_CANARY_INSTANCE_ID"
 const RegionKey = "CAGE_REGION"
 
 func isEmpty(o *string) bool {
@@ -41,7 +43,7 @@ func isEmpty(o *string) bool {
 
 func EnsureEnvars(
 	dest *Envars,
-) (error) {
+) error {
 	// required
 	if isEmpty(dest.Cluster) {
 		return NewErrorf("--cluster [%s] is required", ClusterKey)

--- a/rollout.go
+++ b/rollout.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
-	"strings"
 	"time"
 )
 
@@ -293,12 +292,7 @@ func (envars *Envars) CreateCanaryService(
 		if err := envars.EnsureCanaryInstanceAttribute(awsEcs, &attributeName, &attributeValue); err != nil {
 			return err
 		}
-		var constraintsExpressionBuilder strings.Builder
-		constraintsExpressionBuilder.WriteString("attributes:")
-		constraintsExpressionBuilder.WriteString(attributeName)
-		constraintsExpressionBuilder.WriteString(" == ")
-		constraintsExpressionBuilder.WriteString(attributeValue)
-		constraintsExpression := constraintsExpressionBuilder.String()
+		constraintsExpression := fmt.Sprintf("attributes:%s == %s", attributeName, attributeValue)
 		constraintsType := "memberOf"
 		service.PlacementConstraints = []*ecs.PlacementConstraint{
 			{

--- a/rollout.go
+++ b/rollout.go
@@ -338,7 +338,13 @@ func (envars *Envars) EnsureCanaryInstanceAttribute(
 	}); err != nil {
 		return err
 	} else {
-		if len(out.Attributes) < 1 {
+		canaryInstanceAttribute := make([]*ecs.Attribute, 0)
+		for _, attr := range out.Attributes {
+			if *attr.TargetId == *envars.CanaryInstanceArn && *attr.Value == "true" {
+				canaryInstanceAttribute = append(canaryInstanceAttribute, attr)
+			}
+		}
+		if len(canaryInstanceAttribute) < 1 {
 			log.Infof("put attribute to canary instance(%s)", *envars.CanaryInstanceArn)
 			if _, err := awsEcs.PutAttributes(&ecs.PutAttributesInput{
 				Cluster: envars.Cluster,

--- a/rollout.go
+++ b/rollout.go
@@ -142,9 +142,8 @@ func (envars *Envars) EnsureTaskHealthy(
 				}
 			}
 		} else if *launchType == "EC2" {
-			containerInstanceArn := o.Tasks[0].ContainerInstanceArn
 			if outputs, err := ctx.Ecs.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
-				ContainerInstances: []*string{containerInstanceArn},
+				ContainerInstances: []*string{envars.CanaryInstanceArn},
 			}); err != nil {
 				return err
 			} else {

--- a/rollout.go
+++ b/rollout.go
@@ -283,6 +283,9 @@ func (envars *Envars) CreateCanaryService(
 		*service.DesiredCount = 1
 	}
 	if *service.LaunchType == "EC2" {
+		if envars.CanaryInstanceId == nil {
+			return errors.New("canaryInstanceId option is required when rollout to EC2")
+		}
 		attributeName := *envars.CanaryService
 		attributeValue := "true"
 		if err := envars.EnsureCanaryInstanceAttribute(awsEcs, &attributeName, &attributeValue); err != nil {

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -46,6 +46,7 @@ func (envars *Envars) Setup(ctrl *gomock.Controller, currentTaskCount int64, lau
 	ecsMock.EXPECT().WaitUntilTasksStopped(gomock.Any()).DoAndReturn(mocker.WaitUntilTasksStopped).AnyTimes()
 	ecsMock.EXPECT().ListTasks(gomock.Any()).DoAndReturn(mocker.ListTasks).AnyTimes()
 	ecsMock.EXPECT().DescribeContainerInstances(gomock.Any()).DoAndReturn(mocker.DescribeContainerInstances).AnyTimes()
+	ecsMock.EXPECT().ListAttributes(gomock.Any()).DoAndReturn(mocker.ListAttributes).AnyTimes()
 	albMock.EXPECT().DescribeTargetGroups(gomock.Any()).DoAndReturn(mocker.DescribeTargetGroups).AnyTimes()
 	albMock.EXPECT().DescribeTargetHealth(gomock.Any()).DoAndReturn(mocker.DescribeTargetHealth).AnyTimes()
 	albMock.EXPECT().DescribeTargetGroupAttributes(gomock.Any()).DoAndReturn(mocker.DescribeTargetGroupAttibutes).AnyTimes()
@@ -208,7 +209,9 @@ func TestEnvars_RollOut_EC2(t *testing.T) {
 	defer recoverTimer()
 	for _, v := range []int64{1, 2, 15} {
 		log.Info("====")
+		canaryInstanceArn := "arn:aws:ecs:us-west-2:1234567689012:container-instance/abcdefg-hijk-lmn-opqrstuvwxyz"
 		envars := DefaultEnvars()
+		envars.CanaryInstanceArn = &canaryInstanceArn
 		ctrl := gomock.NewController(t)
 		mctx, ctx := envars.Setup(ctrl, v, "EC2")
 		if mctx.ServiceSize() != 1 {

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -70,7 +70,7 @@ func (envars *Envars) Setup(ctrl *gomock.Controller, currentTaskCount int64, lau
 	return mocker, ecsMock, albMock
 }
 
-func SetupContext(ecsMock *mock_ecs.MockECSAPI, albMock *mock_elbv2.MockELBV2API) *Context {
+func MakeContext(ecsMock *mock_ecs.MockECSAPI, albMock *mock_elbv2.MockELBV2API) *Context {
 	return &Context{
 		Ecs: ecsMock,
 		Alb: albMock,
@@ -86,7 +86,7 @@ func TestEnvars_RollOut(t *testing.T) {
 		envars := DefaultEnvars()
 		ctrl := gomock.NewController(t)
 		mctx, ecsMock, albMock := envars.Setup(ctrl, v, "FARGATE")
-		ctx := SetupContext(ecsMock, albMock)
+		ctx := MakeContext(ecsMock, albMock)
 		if mctx.ServiceSize() != 1 {
 			t.Fatalf("current service not setup")
 		}
@@ -113,7 +113,7 @@ func TestEnvars_StartGradualRollOut2(t *testing.T) {
 	envars.ServiceDefinitionBase64 = aws.String(base64.StdEncoding.EncodeToString(d))
 	ctrl := gomock.NewController(t)
 	mocker, ecsMock, albMock := envars.Setup(ctrl, 2, "FARGATE")
-	ctx := SetupContext(ecsMock, albMock)
+	ctx := MakeContext(ecsMock, albMock)
 	result := envars.RollOut(ctx)
 	if result.Error != nil {
 		t.Fatalf(result.Error.Error())
@@ -148,7 +148,7 @@ func TestEnvars_RollOut2(t *testing.T) {
 		}, nil).Times(2),
 		albMock.EXPECT().DescribeTargetHealth(gomock.Any()).DoAndReturn(mocker.DescribeTargetHealth).AnyTimes(),
 	)
-	ctx := SetupContext(ecsMock, albMock)
+	ctx := MakeContext(ecsMock, albMock)
 	result := envars.RollOut(ctx)
 	if result.Error != nil {
 		t.Fatalf(result.Error.Error())
@@ -185,7 +185,7 @@ func TestEnvars_RollOut3(t *testing.T) {
 			},
 		}},
 	}, nil).AnyTimes()
-	ctx := SetupContext(ecsMock, albMock)
+	ctx := MakeContext(ecsMock, albMock)
 	result := envars.RollOut(ctx)
 	assert.NotNil(t, result.Error)
 }
@@ -202,7 +202,7 @@ func TestEnvars_StartGradualRollOut5(t *testing.T) {
 	envars.ServiceDefinitionBase64 = aws.String(base64.StdEncoding.EncodeToString(o))
 	ctrl := gomock.NewController(t)
 	_, ecsMock, albMock := envars.Setup(ctrl, 2, "FARGATE")
-	ctx := SetupContext(ecsMock, albMock)
+	ctx := MakeContext(ecsMock, albMock)
 	if res := envars.RollOut(ctx); res.Error != nil {
 		t.Fatalf(res.Error.Error())
 	} else if res.ServiceIntact {
@@ -230,7 +230,7 @@ func TestEnvars_RollOut_EC2(t *testing.T) {
 				},
 			},
 		}, nil).AnyTimes()
-		ctx := SetupContext(ecsMock, albMock)
+		ctx := MakeContext(ecsMock, albMock)
 		if mctx.ServiceSize() != 1 {
 			t.Fatalf("current service not setup")
 		}
@@ -254,7 +254,7 @@ func TestEnvars_RollOut_EC2_without_ContainerInstanceArn(t *testing.T) {
 	envars := DefaultEnvars()
 	ctrl := gomock.NewController(t)
 	mctx, ecsMock, albMock := envars.Setup(ctrl, 1, "EC2")
-	ctx := SetupContext(ecsMock, albMock)
+	ctx := MakeContext(ecsMock, albMock)
 	if mctx.ServiceSize() != 1 {
 		t.Fatalf("current service not setup")
 	}
@@ -288,7 +288,7 @@ func TestEnvars_RollOut_EC2_no_attribute(t *testing.T) {
 		Attributes: []*ecs.Attribute{},
 	}, nil).AnyTimes()
 	ecsMock.EXPECT().PutAttributes(gomock.Any()).Return(&ecs.PutAttributesOutput{}, nil).AnyTimes()
-	ctx := SetupContext(ecsMock, albMock)
+	ctx := MakeContext(ecsMock, albMock)
 	result := envars.RollOut(ctx)
 	if result.Error != nil {
 		t.Fatalf("%s", result.Error)

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -28,7 +28,7 @@ func DefaultEnvars() *Envars {
 	}
 }
 
-func (envars *Envars) Setup(ctrl *gomock.Controller, currentTaskCount int64, launchType string) (*test.MockContext, *Context) {
+func (envars *Envars) Setup(ctrl *gomock.Controller, currentTaskCount int64, launchType string) (*test.MockContext, *mock_ecs.MockECSAPI, *mock_elbv2.MockELBV2API) {
 	ecsMock := mock_ecs.NewMockECSAPI(ctrl)
 	albMock := mock_elbv2.NewMockELBV2API(ctrl)
 	mocker := test.NewMockContext()
@@ -68,7 +68,11 @@ func (envars *Envars) Setup(ctrl *gomock.Controller, currentTaskCount int64, lau
 		LaunchType:     aws.String(launchType),
 	}
 	_, _ = mocker.CreateService(a)
-	return mocker, &Context{
+	return mocker, ecsMock, albMock
+}
+
+func SetupContext(ecsMock *mock_ecs.MockECSAPI, albMock *mock_elbv2.MockELBV2API) *Context {
+	return &Context{
 		Ecs: ecsMock,
 		Alb: albMock,
 	}
@@ -82,7 +86,8 @@ func TestEnvars_RollOut(t *testing.T) {
 		log.Info("====")
 		envars := DefaultEnvars()
 		ctrl := gomock.NewController(t)
-		mctx, ctx := envars.Setup(ctrl, v, "FARGATE")
+		mctx, ecsMock, albMock := envars.Setup(ctrl, v, "FARGATE")
+		ctx := SetupContext(ecsMock, albMock)
 		if mctx.ServiceSize() != 1 {
 			t.Fatalf("current service not setup")
 		}
@@ -108,7 +113,8 @@ func TestEnvars_StartGradualRollOut2(t *testing.T) {
 	d, _ := ioutil.ReadFile("fixtures/service.json")
 	envars.ServiceDefinitionBase64 = aws.String(base64.StdEncoding.EncodeToString(d))
 	ctrl := gomock.NewController(t)
-	mocker, ctx := envars.Setup(ctrl, 2, "FARGATE")
+	mocker, ecsMock, albMock := envars.Setup(ctrl, 2, "FARGATE")
+	ctx := SetupContext(ecsMock, albMock)
 	result := envars.RollOut(ctx)
 	if result.Error != nil {
 		t.Fatalf(result.Error.Error())
@@ -126,7 +132,7 @@ func TestEnvars_RollOut2(t *testing.T) {
 	d, _ := ioutil.ReadFile("fixtures/service.json")
 	envars.ServiceDefinitionBase64 = aws.String(base64.StdEncoding.EncodeToString(d))
 	ctrl := gomock.NewController(t)
-	mocker, ctx := envars.Setup(ctrl, 2, "FARGATE")
+	mocker, ecsMock, _ := envars.Setup(ctrl, 2, "FARGATE")
 	albMock := mock_elbv2.NewMockELBV2API(ctrl)
 	gomock.InOrder(
 		albMock.EXPECT().DescribeTargetHealth(gomock.Any()).Return(&elbv2.DescribeTargetHealthOutput{
@@ -143,7 +149,7 @@ func TestEnvars_RollOut2(t *testing.T) {
 		}, nil).Times(2),
 		albMock.EXPECT().DescribeTargetHealth(gomock.Any()).DoAndReturn(mocker.DescribeTargetHealth).AnyTimes(),
 	)
-	ctx.Alb = albMock
+	ctx := SetupContext(ecsMock, albMock)
 	result := envars.RollOut(ctx)
 	if result.Error != nil {
 		t.Fatalf(result.Error.Error())
@@ -157,7 +163,7 @@ func TestEnvars_RollOut3(t *testing.T) {
 	d, _ := ioutil.ReadFile("fixtures/service.json")
 	envars.ServiceDefinitionBase64 = aws.String(base64.StdEncoding.EncodeToString(d))
 	ctrl := gomock.NewController(t)
-	_, ctx := envars.Setup(ctrl, 2, "FARGATE")
+	_, ecsMock, _ := envars.Setup(ctrl, 2, "FARGATE")
 	albMock := mock_elbv2.NewMockELBV2API(ctrl)
 	albMock.EXPECT().DescribeTargetHealth(gomock.Any()).Return(&elbv2.DescribeTargetHealthOutput{
 		TargetHealthDescriptions: []*elbv2.TargetHealthDescription{{
@@ -180,7 +186,7 @@ func TestEnvars_RollOut3(t *testing.T) {
 			},
 		}},
 	}, nil).AnyTimes()
-	ctx.Alb = albMock
+	ctx := SetupContext(ecsMock, albMock)
 	result := envars.RollOut(ctx)
 	assert.NotNil(t, result.Error)
 }
@@ -196,7 +202,8 @@ func TestEnvars_StartGradualRollOut5(t *testing.T) {
 	o, _ := json.Marshal(input)
 	envars.ServiceDefinitionBase64 = aws.String(base64.StdEncoding.EncodeToString(o))
 	ctrl := gomock.NewController(t)
-	_, ctx := envars.Setup(ctrl, 2, "FARGATE")
+	_, ecsMock, albMock := envars.Setup(ctrl, 2, "FARGATE")
+	ctx := SetupContext(ecsMock, albMock)
 	if res := envars.RollOut(ctx); res.Error != nil {
 		t.Fatalf(res.Error.Error())
 	} else if res.ServiceIntact {
@@ -213,7 +220,8 @@ func TestEnvars_RollOut_EC2(t *testing.T) {
 		envars := DefaultEnvars()
 		envars.CanaryInstanceArn = &canaryInstanceArn
 		ctrl := gomock.NewController(t)
-		mctx, ctx := envars.Setup(ctrl, v, "EC2")
+		mctx, ecsMock, albMock := envars.Setup(ctrl, v, "EC2")
+		ctx := SetupContext(ecsMock, albMock)
 		if mctx.ServiceSize() != 1 {
 			t.Fatalf("current service not setup")
 		}
@@ -229,7 +237,57 @@ func TestEnvars_RollOut_EC2(t *testing.T) {
 		assert.Equal(t, v, mctx.TaskSize())
 	}
 }
-
+func TestEnvars_RollOut_EC2_without_ContainerInstanceArn(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	newTimer = fakeTimer
+	defer recoverTimer()
+	log.Info("====")
+	envars := DefaultEnvars()
+	ctrl := gomock.NewController(t)
+	mctx, ecsMock, albMock := envars.Setup(ctrl, 1, "EC2")
+	ctx := SetupContext(ecsMock, albMock)
+	if mctx.ServiceSize() != 1 {
+		t.Fatalf("current service not setup")
+	}
+	if taskCnt := mctx.TaskSize(); taskCnt != 1 {
+		t.Fatalf("current tasks not setup: %d/%d", 1, taskCnt)
+	}
+	result := envars.RollOut(ctx)
+	if result.Error == nil {
+		t.Fatal("Rollout with no container instance should be error")
+	} else {
+		assert.Equal(t, "canaryInstanceArn option is required when rollout to EC2", result.Error.Error())
+	}
+}
+func TestEnvars_RollOut_EC2_no_attribute(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	newTimer = fakeTimer
+	defer recoverTimer()
+	log.Info("====")
+	canaryInstanceArn := "arn:aws:ecs:us-west-2:1234567689012:container-instance/abcdefg-hijk-lmn-opqrstuvwxyz"
+	envars := DefaultEnvars()
+	envars.CanaryInstanceArn = &canaryInstanceArn
+	ctrl := gomock.NewController(t)
+	mctx, ecsMock, albMock := envars.Setup(ctrl, 1, "EC2")
+	if mctx.ServiceSize() != 1 {
+		t.Fatalf("current service not setup")
+	}
+	if taskCnt := mctx.TaskSize(); taskCnt != 1 {
+		t.Fatalf("current tasks not setup: %d/%d", 1, taskCnt)
+	}
+	ecsMock.EXPECT().ListAttributes(gomock.Any()).Return(&ecs.ListAttributesOutput{
+		Attributes: []*ecs.Attribute{},
+	}, nil).AnyTimes()
+	ecsMock.EXPECT().PutAttributes(gomock.Any()).Return(&ecs.PutAttributesOutput{}, nil).AnyTimes()
+	ctx := SetupContext(ecsMock, albMock)
+	result := envars.RollOut(ctx)
+	if result.Error != nil {
+		t.Fatalf("%s", result.Error)
+	}
+	assert.False(t, result.ServiceIntact)
+	assert.Equal(t, int64(1), mctx.ServiceSize())
+	assert.Equal(t, int64(1), mctx.TaskSize())
+}
 func TestEnvars_CreateNextTaskDefinition(t *testing.T) {
 	envars := &Envars{
 		TaskDefinitionArn: aws.String("arn://task"),

--- a/test/context.go
+++ b/test/context.go
@@ -332,6 +332,24 @@ func (ctx *MockContext) DescribeContainerInstances(input *ecs.DescribeContainerI
 		ContainerInstances: ret,
 	}, nil
 }
+func (ctx *MockContext) ListAttributes(input *ecs.ListAttributesInput) (*ecs.ListAttributesOutput, error) {
+	ctx.mux.Lock()
+	defer ctx.mux.Unlock()
+	value := "true"
+	// NOTE: urakami
+	// rollout_test.goに同じ文字列をハードコーディングしている。
+	// どこかで共通化したいが、良いアイディアが思い浮かばない。
+	targetId := "arn:aws:ecs:us-west-2:1234567689012:container-instance/abcdefg-hijk-lmn-opqrstuvwxyz"
+	return &ecs.ListAttributesOutput{
+		Attributes: []*ecs.Attribute{
+			{
+				Name:     input.AttributeName,
+				Value:    &value,
+				TargetId: &targetId,
+			},
+		},
+	}, nil
+}
 
 //
 

--- a/test/context.go
+++ b/test/context.go
@@ -332,24 +332,6 @@ func (ctx *MockContext) DescribeContainerInstances(input *ecs.DescribeContainerI
 		ContainerInstances: ret,
 	}, nil
 }
-func (ctx *MockContext) ListAttributes(input *ecs.ListAttributesInput) (*ecs.ListAttributesOutput, error) {
-	ctx.mux.Lock()
-	defer ctx.mux.Unlock()
-	value := "true"
-	// NOTE: urakami
-	// rollout_test.goに同じ文字列をハードコーディングしている。
-	// どこかで共通化したいが、良いアイディアが思い浮かばない。
-	targetId := "arn:aws:ecs:us-west-2:1234567689012:container-instance/abcdefg-hijk-lmn-opqrstuvwxyz"
-	return &ecs.ListAttributesOutput{
-		Attributes: []*ecs.Attribute{
-			{
-				Name:     input.AttributeName,
-				Value:    &value,
-				TargetId: &targetId,
-			},
-		},
-	}, nil
-}
 
 //
 


### PR DESCRIPTION
close #21 

- `rollout` コマンドに `canaryInstanceArn` というオプションを追加しました
- canary-serviceと同名のattributeが設定されているインスタンスにcanary-serviceを配置します
- `canaryInstanceArn` で入力されたコンテナインスタンスにattributeが設定されていなかったら、canary-service起動前に `putAttributes` します