### PR TITLE
fix: canaryInstanceArnオプションをenvarsにマージできていなかった #23

### DIFF
--- a/env.go
+++ b/env.go
@@ -106,6 +106,9 @@ func (e *Envars) Merge(o *Envars) error {
 	if !isEmpty(o.CanaryService) {
 		e.CanaryService = o.CanaryService
 	}
+	if !isEmpty(o.CanaryInstanceArn) {
+		e.CanaryInstanceArn = o.CanaryInstanceArn
+	}
 	if !isEmpty(o.TaskDefinitionBase64) {
 		e.TaskDefinitionBase64 = o.TaskDefinitionBase64
 	}


### PR DESCRIPTION
close #23 

#22 で追加したオプションのマージが漏れていました