### PR TITLE
fix: Skip deregistration from target group 

### DIFF
--- a/cli/cage/commands/flags.go
+++ b/cli/cage/commands/flags.go
@@ -40,6 +40,16 @@ func TaskDefinitionArnFlag(dest *string) cli.Flag {
 	}
 }
 
+func CanaryTaskIdleDurationFlag(dest *int) cli.Flag {
+	return cli.IntFlag{
+		Name: "canaryTaskIdleDuration",
+		EnvVar:  cage.CanaryTaskIdleDuration,
+		Usage : "Idle duration seconds for ensuring canary task that has no attached load balancer",
+		Destination: dest,
+		Value: 10,
+	}
+}
+
 func (c *cageCommands) aggregateEnvars(
 	ctx *cli.Context,
 	envars *cage.Envars,

--- a/cli/cage/commands/rollout.go
+++ b/cli/cage/commands/rollout.go
@@ -23,6 +23,7 @@ func (c *cageCommands) RollOut() cli.Command {
 			ClusterFlag(&envars.Cluster),
 			ServiceFlag(&envars.Service),
 			TaskDefinitionArnFlag(&envars.TaskDefinitionArn),
+			CanaryTaskIdleDurationFlag(&envars.CanaryTaskIdleDuration),
 			cli.StringFlag{
 				Name:        "canaryInstanceArn",
 				EnvVar:      cage.CanaryInstanceArnKey,

--- a/cli/cage/commands/up.go
+++ b/cli/cage/commands/up.go
@@ -23,6 +23,7 @@ func (c *cageCommands) Up() cli.Command {
 			ClusterFlag(&envars.Cluster),
 			ServiceFlag(&envars.Service),
 			TaskDefinitionArnFlag(&envars.TaskDefinitionArn),
+			CanaryTaskIdleDurationFlag(&envars.CanaryTaskIdleDuration),
 		},
 		Action: func(ctx *cli.Context) error {
 			c.aggregateEnvars(ctx, &envars)

--- a/cli/cage/main.go
+++ b/cli/cage/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	app := cli.NewApp()
 	app.Name = "canarycage"
-	app.Version = "3.2.1"
+	app.Version = "3.2.2"
 	app.Description = "A gradual roll-out deployment tool for AWS ECS"
 	ctx := context.Background()
 	cmds := commands.NewCageCommands(ctx)

--- a/env.go
+++ b/env.go
@@ -18,6 +18,7 @@ type Envars struct {
 	TaskDefinitionArn      string `json:"nextTaskDefinitionArn" type:"string"`
 	TaskDefinitionInput    *ecs.RegisterTaskDefinitionInput
 	ServiceDefinitionInput *ecs.CreateServiceInput
+	CanaryTaskIdleDuration int
 }
 
 // required
@@ -30,6 +31,7 @@ const TaskDefinitionArnKey = "CAGE_TASK_DEFINITION_ARN"
 // optional
 const CanaryInstanceArnKey = "CAGE_CANARY_INSTANCE_ARN"
 const RegionKey = "CAGE_REGION"
+const CanaryTaskIdleDuration = "CAGE_CANARY_TASK_IDLE_DURATION"
 
 func EnsureEnvars(
 	dest *Envars,

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,15 @@ module github.com/loilo-inc/canarycage
 require (
 	github.com/apex/log v1.0.0
 	github.com/aws/aws-sdk-go v1.17.3
-	github.com/davecgh/go-spew v1.1.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/mock v1.1.1
 	github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-	github.com/pkg/errors v0.8.0
-	github.com/pmezard/go-difflib v1.0.0
+	github.com/pkg/errors v0.8.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 	github.com/urfave/cli v1.20.0
-	golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a
+	golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a // indirect
+	golang.org/x/text v0.3.2 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -20,3 +20,6 @@ github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a h1:8fCF9zjAir2SP3N+axz9xs+0r4V8dqPzqsWO10t8zoo=
 golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -208,6 +208,7 @@ func TestCage_StartGradualRollOut5(t *testing.T) {
 	newTimer = fakeTimer
 	defer recoverTimer()
 	envars.ServiceDefinitionInput.LoadBalancers = nil
+	envars.CanaryTaskIdleDuration = 1
 	ctrl := gomock.NewController(t)
 	_, ecsMock, albMock, ec2Mock := Setup(ctrl, envars, 2, "FARGATE")
 	cagecli := NewCage(&Input{

--- a/test/context.go
+++ b/test/context.go
@@ -224,6 +224,7 @@ func (ctx *MockContext) StartTask(input *ecs.StartTaskInput) (*ecs.StartTaskOutp
 	} else {
 		ret.ContainerInstanceArn = aws.String("arn:aws:ecs:us-west-2:1234567890:container-instance/12345678-hoge-hoge-1234-1f2o3o4ba5r")
 	}
+	ret.LastStatus = aws.String("RUNNING")
 	return &ecs.StartTaskOutput{
 		Tasks: []*ecs.Task{ret},
 	}, nil


### PR DESCRIPTION
Skip deregistration from target group when no LB attached to service.