### PR TITLE
fix: Aligning the FARGATE platform version of canarytask with the service

### DIFF
--- a/rollout.go
+++ b/rollout.go
@@ -262,6 +262,7 @@ func (c *cage) StartCanaryTask(nextTaskDefinition *ecs.TaskDefinition) (*StartCa
 			NetworkConfiguration: service.NetworkConfiguration,
 			TaskDefinition:       nextTaskDefinition.TaskDefinitionArn,
 			LaunchType:           aws.String("FARGATE"),
+			PlatformVersion:      service.PlatformVersion,
 		}); err != nil {
 			return nil, err
 		} else {


### PR DESCRIPTION
There was a case that the canary task could not be started with a service that uses a version other than the "LATEST" platform version, so I changed to use the same platform version as the service.