### PR TITLE
fix: restore default wait timeout for task/service stable into 5s to 15s

### DIFF
--- a/cage.go
+++ b/cage.go
@@ -46,6 +46,6 @@ func NewCage(input *Input) Cage {
 		Alb:     input.ALB,
 		Ec2:     input.EC2,
 		Time:    input.Time,
-		MaxWait: 5 * time.Minute,
+		MaxWait: 15 * time.Minute,
 	}
 }


### PR DESCRIPTION
This is hotfix for degradation from 4.0. Default wait timeout has been reduced to 5s from 15s in 4.0, causing easy wait timeout at confirming new service stability. We just reverted the change.