### PR TITLE
gha: fetch-tags = true for release

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"


### PR DESCRIPTION
Fix for

> release failed after 0s                  error=git doesn't contain any tags. Either add a tag or use --snapshot
> https://github.com/loilo-inc/canarycage/actions/runs/10007615861/job/27662680323