### PR TITLE
Revert "gha: fetch-tags = true for release (#88)"

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          fetch-tags: true
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"


### PR DESCRIPTION
This reverts commit d19153a49c76149316a9ac3453fcff8bf3429724.

It didn't solve the release problem: https://github.com/loilo-inc/canarycage/actions/runs/10033616953/job/27727010112