### PR TITLE
Revert "chore: use semver tag_sort for release"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,8 +9,6 @@ builds:
     goarch:
       - amd64
       - arm64
-git:
-  tag_sort: semver
 archives:
   - format: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
Reverts loilo-inc/canarycage#87

Fix for

> release failed after 0s                  error=git doesn't contain any tags. Either add a tag or use --snapshot
> https://github.com/loilo-inc/canarycage/actions/runs/10007615861/job/27662680323

`tag_sort: semver` is available only for goreleaser-pro: [schema-pro.json](https://github.com/goreleaser/goreleaser/blob/137855902e33dfcf6f1fa470833b0028ab5440b9/www/docs/static/schema-pro.json#L1369C1-L1369C16) v.s. [schema.json](https://github.com/goreleaser/goreleaser/blob/137855902e33dfcf6f1fa470833b0028ab5440b9/www/docs/static/schema.json#L1088)