### PR TITLE
fix: wait 2sec before NewTasksRunningWaiter

### DIFF
--- a/run.go
+++ b/run.go
@@ -2,6 +2,7 @@ package cage
 
 import (
 	"context"
+	"time"
 
 	"github.com/apex/log"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -46,6 +47,11 @@ func (c *cage) Run(ctx context.Context, input *types.RunInput) (*types.RunResult
 		return nil, err
 	}
 	taskArn := o.Tasks[0].TaskArn
+
+	// NOTE: https://github.com/loilo-inc/canarycage/issues/93
+	// wait for the task to be running
+	time.Sleep(2 * time.Second)
+
 	log.Infof("waiting for task '%s' to start...", *taskArn)
 	if err := ecs.NewTasksRunningWaiter(ecsCli).Wait(ctx, &ecs.DescribeTasksInput{
 		Cluster: &env.Cluster,

--- a/task/common.go
+++ b/task/common.go
@@ -69,6 +69,11 @@ func (c *common) waitForTaskRunning(ctx context.Context) error {
 	}
 	env := c.di.Get(key.Env).(*env.Envars)
 	ecsCli := c.di.Get(key.EcsCli).(awsiface.EcsClient)
+
+	// NOTE: https://github.com/loilo-inc/canarycage/issues/93
+	// wait for the task to be running
+	time.Sleep(2 * time.Second)
+
 	log.Infof("🥚 waiting for canary task '%s' is running...", *c.taskArn)
 	if err := ecs.NewTasksRunningWaiter(ecsCli).Wait(ctx, &ecs.DescribeTasksInput{
 		Cluster: &env.Cluster,


### PR DESCRIPTION
fix #93 

To resolve the issue where ecs.NewTasksRunningWaiter fails when executed too early, I added a 2-second delay before running it.