### PR TITLE
fix: do not count target as "unhealthy" while target health is "initial"

### DIFF
--- a/task/alb_task.go
+++ b/task/alb_task.go
@@ -205,6 +205,8 @@ func (c *albTask) waitUntilTargetHealthy(
 				switch *recentState {
 				case elbv2types.TargetHealthStateEnumHealthy:
 					return nil
+				case elbv2types.TargetHealthStateEnumInitial:
+					continue
 				default:
 					notHealthyCount++
 				}


### PR DESCRIPTION
Currently, target health check for a canary task is executed by fixed count and interval. 

This behavior is undesirable for target group that has relatively long health check  interval, because health check by cage may fail before target status goes `healthy` from `initial`.