### PR TITLE
Update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
       - name: Check mod
@@ -21,7 +21,7 @@ jobs:
       - run: go build
       - run: go build github.com/loilo-inc/canarycage/cli/cage
       - run: go test ./... -coverprofile=coverage.txt -covermode=count
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -10,10 +10,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
       - name: Release


### PR DESCRIPTION
Bump actions/checkout to v6, actions/setup-go to v6, and codecov/codecov-action to v5 in push and tag workflows to use the latest major releases and ensure continued support and security.