### PR TITLE
Set default highest severity to UNDEFINED

### DIFF
--- a/cli/cage/audit/aggregator.go
+++ b/cli/cage/audit/aggregator.go
@@ -47,7 +47,7 @@ type AggregateResult struct {
 
 func (a *aggregater) SummarizeTotal() *AggregateResult {
 	result := &AggregateResult{}
-	highest := ecrtypes.FindingSeverityInformational
+	highest := ecrtypes.FindingSeverityUndefined
 	for cve := range a.cves {
 		severity := a.cves[cve].Severity
 		switch severity {
@@ -71,7 +71,7 @@ func (a *aggregater) SummarizeTotal() *AggregateResult {
 		highest = ecrtypes.FindingSeverityMedium
 	} else if result.LowCount > 0 {
 		highest = ecrtypes.FindingSeverityLow
-	} else {
+	} else if result.InfoCount > 0 {
 		highest = ecrtypes.FindingSeverityInformational
 	}
 	result.HighestSeverity = highest

--- a/cli/cage/audit/aggregator_test.go
+++ b/cli/cage/audit/aggregator_test.go
@@ -249,6 +249,11 @@ func TestAggregater_SummarizeTotal(t *testing.T) {
 			})
 		}
 	})
+	t.Run("set highest to UNDEFINED if no vulns", func(t *testing.T) {
+		agg := NewAggregater()
+		result := agg.SummarizeTotal()
+		assert.Equal(t, ecrtypes.FindingSeverityUndefined, result.HighestSeverity)
+	})
 }
 
 func TestAggregateResult_SeverityCounts(t *testing.T) {


### PR DESCRIPTION
Initialize highest severity to ecrtypes.FindingSeverityUndefined and only set it to Informational when InfoCount > 0. This prevents SummarizeTotal from reporting Informational when there are no findings. Added a unit test to assert HighestSeverity is UNDEFINED for a new/empty aggregater.