### PR TITLE
feat: Add policy command and IAM policy generator 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.so
 *.dylib
 .DS_Store
-cage
 
 # Test binary, build with `go test -c`
 *.test

--- a/cli/cage/commands/policy.go
+++ b/cli/cage/commands/policy.go
@@ -6,19 +6,19 @@ import (
 )
 
 func Policy() *cli.Command {
-	var pretty bool
+	var short bool
 	return &cli.Command{
 		Name:  "policy",
 		Usage: "output IAM policy required for canarycage",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:        "pretty",
-				Usage:       "output indented JSON",
-				Destination: &pretty,
+				Name:        "short",
+				Usage:       "output short format",
+				Destination: &short,
 			},
 		},
 		Action: func(ctx *cli.Context) error {
-			cmd := policy.NewCommand(ctx.App.Writer, pretty)
+			cmd := policy.NewCommand(ctx.App.Writer, short)
 			return cmd.Run()
 		},
 	}

--- a/cli/cage/commands/policy.go
+++ b/cli/cage/commands/policy.go
@@ -1,0 +1,25 @@
+package commands
+
+import (
+	"github.com/loilo-inc/canarycage/cli/cage/policy"
+	"github.com/urfave/cli/v2"
+)
+
+func Policy() *cli.Command {
+	var pretty bool
+	return &cli.Command{
+		Name:  "policy",
+		Usage: "output IAM policy required for canarycage",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "pretty",
+				Usage:       "output indented JSON",
+				Destination: &pretty,
+			},
+		},
+		Action: func(ctx *cli.Context) error {
+			cmd := policy.NewCommand(ctx.App.Writer, pretty)
+			return cmd.Run()
+		},
+	}
+}

--- a/cli/cage/commands/policy_test.go
+++ b/cli/cage/commands/policy_test.go
@@ -15,10 +15,10 @@ func TestPolicy(t *testing.T) {
 	assert.Equal(t, "output IAM policy required for canarycage", cmd.Usage)
 	assert.Len(t, cmd.Flags, 1)
 
-	prettyFlag, ok := cmd.Flags[0].(*cli.BoolFlag)
+	shortFlag, ok := cmd.Flags[0].(*cli.BoolFlag)
 	assert.True(t, ok)
-	assert.Equal(t, "pretty", prettyFlag.Name)
-	assert.Equal(t, "output indented JSON", prettyFlag.Usage)
+	assert.Equal(t, "short", shortFlag.Name)
+	assert.Equal(t, "output short format", shortFlag.Usage)
 }
 
 func TestPolicyAction(t *testing.T) {
@@ -28,12 +28,12 @@ func TestPolicyAction(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name: "without pretty flag",
+			name: "without short flag",
 			args: []string{"cage", "policy"},
 		},
 		{
-			name: "with pretty flag",
-			args: []string{"cage", "policy", "--pretty"},
+			name: "with short flag",
+			args: []string{"cage", "policy", "--short"},
 		},
 	}
 

--- a/cli/cage/commands/policy_test.go
+++ b/cli/cage/commands/policy_test.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+func TestPolicy(t *testing.T) {
+	cmd := Policy()
+
+	assert.Equal(t, "policy", cmd.Name)
+	assert.Equal(t, "output IAM policy required for canarycage", cmd.Usage)
+	assert.Len(t, cmd.Flags, 1)
+
+	prettyFlag, ok := cmd.Flags[0].(*cli.BoolFlag)
+	assert.True(t, ok)
+	assert.Equal(t, "pretty", prettyFlag.Name)
+	assert.Equal(t, "output indented JSON", prettyFlag.Usage)
+}
+
+func TestPolicyAction(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			name: "without pretty flag",
+			args: []string{"cage", "policy"},
+		},
+		{
+			name: "with pretty flag",
+			args: []string{"cage", "policy", "--pretty"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			app := &cli.App{
+				Commands: []*cli.Command{Policy()},
+				Writer:   buf,
+			}
+			err := app.Run(tt.args)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/cli/cage/main.go
+++ b/cli/cage/main.go
@@ -41,6 +41,7 @@ func main() {
 		cmds.Run(cageapp.NewCageCmdInput(os.Stdin, configCmdInput)),
 		commands.Upgrade(cageapp.NewUpgradeCmdInput(upgradeCmdInput), upgrade.ProvideUpgradeDI),
 		commands.Audit(appConf, audit.ProvideAuditCmd),
+		commands.Policy(),
 	}
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{

--- a/cli/cage/policy/command.go
+++ b/cli/cage/policy/command.go
@@ -1,0 +1,33 @@
+package policy
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Command struct {
+	Writer io.Writer
+	Pretty bool
+}
+
+func NewCommand(writer io.Writer, pretty bool) *Command {
+	return &Command{Writer: writer, Pretty: pretty}
+}
+
+func (c *Command) Run() error {
+	doc := DefaultDocument()
+	var (
+		out []byte
+		err error
+	)
+	if c.Pretty {
+		out, err = json.MarshalIndent(doc, "", "  ")
+	} else {
+		out, err = json.Marshal(doc)
+	}
+	if err != nil {
+		return err
+	}
+	_, err = c.Writer.Write(append(out, '\n'))
+	return err
+}

--- a/cli/cage/policy/command.go
+++ b/cli/cage/policy/command.go
@@ -7,11 +7,11 @@ import (
 
 type Command struct {
 	Writer io.Writer
-	Pretty bool
+	Short  bool
 }
 
-func NewCommand(writer io.Writer, pretty bool) *Command {
-	return &Command{Writer: writer, Pretty: pretty}
+func NewCommand(writer io.Writer, short bool) *Command {
+	return &Command{Writer: writer, Short: short}
 }
 
 func (c *Command) Run() error {
@@ -20,7 +20,7 @@ func (c *Command) Run() error {
 		out []byte
 		err error
 	)
-	if c.Pretty {
+	if !c.Short {
 		out, err = json.MarshalIndent(doc, "", "  ")
 	} else {
 		out, err = json.Marshal(doc)

--- a/cli/cage/policy/command_test.go
+++ b/cli/cage/policy/command_test.go
@@ -1,0 +1,25 @@
+package policy
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestCommandRunPretty(t *testing.T) {
+	buf := &bytes.Buffer{}
+	cmd := NewCommand(buf, true)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run() error: %s", err)
+	}
+	var doc Document
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid json output: %s", err)
+	}
+	if doc.Version == "" {
+		t.Fatalf("expected version to be set")
+	}
+	if len(doc.Statement) == 0 {
+		t.Fatalf("expected at least one statement")
+	}
+}

--- a/cli/cage/policy/document.go
+++ b/cli/cage/policy/document.go
@@ -1,0 +1,57 @@
+package policy
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/loilo-inc/canarycage/awsiface"
+)
+
+type Statement struct {
+	Effect   string   `json:"Effect"`
+	Action   []string `json:"Action"`
+	Resource string   `json:"Resource"`
+}
+
+type Document struct {
+	Version   string      `json:"Version"`
+	Statement []Statement `json:"Statement"`
+}
+
+type serviceSpec struct {
+	prefix string
+	iface  reflect.Type
+}
+
+var serviceSpecs = []serviceSpec{
+	{prefix: "ecs", iface: reflect.TypeFor[awsiface.EcsClient]()},
+	{prefix: "ecr", iface: reflect.TypeFor[awsiface.EcrClient]()},
+	{prefix: "elbv2", iface: reflect.TypeFor[awsiface.AlbClient]()},
+	{prefix: "ec2", iface: reflect.TypeFor[awsiface.Ec2Client]()},
+}
+
+func DefaultDocument() Document {
+	statements := make([]Statement, 0, len(serviceSpecs))
+	for _, spec := range serviceSpecs {
+		actions := actionsForInterface(spec.prefix, spec.iface)
+		statements = append(statements, Statement{
+			Effect:   "Allow",
+			Action:   actions,
+			Resource: "*",
+		})
+	}
+	return Document{
+		Version:   "2012-10-17",
+		Statement: statements,
+	}
+}
+
+func actionsForInterface(prefix string, iface reflect.Type) []string {
+	actions := make([]string, 0, iface.NumMethod())
+	for i := 0; i < iface.NumMethod(); i++ {
+		method := iface.Method(i)
+		actions = append(actions, prefix+":"+method.Name)
+	}
+	sort.Strings(actions)
+	return actions
+}

--- a/cli/cage/policy/document_test.go
+++ b/cli/cage/policy/document_test.go
@@ -1,0 +1,19 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultDocumentIncludesActions(t *testing.T) {
+	doc := DefaultDocument()
+	assert.Equal(t, "2012-10-17", doc.Version)
+	if assert.Len(t, doc.Statement, len(serviceSpecs)) {
+		for _, stmt := range doc.Statement {
+			assert.Equal(t, "Allow", stmt.Effect)
+			assert.Equal(t, "*", stmt.Resource)
+			assert.NotEmpty(t, stmt.Action)
+		}
+	}
+}


### PR DESCRIPTION
Add a new `policy` CLI command (commands.Policy) that outputs the IAM policy required for canarycage.