### PR TITLE
doc(audit): Clarify audit command ArgsUsage

### DIFF
--- a/cli/cage/commands/audit.go
+++ b/cli/cage/commands/audit.go
@@ -14,7 +14,7 @@ func Audit(app *cageapp.App, provider cageapp.AuditCmdProvider) *cli.Command {
 	return &cli.Command{
 		Name:      "audit",
 		Usage:     "Audit container images used in an ECS service",
-		ArgsUsage: "[directory path of service.json and task-definition.json]",
+		ArgsUsage: "[directory path of service.json]",
 		Flags: []cli.Flag{
 			cageapp.RegionFlag(&input.Region),
 			cageapp.ClusterFlag(&input.Cluster),


### PR DESCRIPTION
Update the audit CLI command's ArgsUsage to indicate only the directory path of service.json is required, removing the reference to task-definition.json to clarify the expected argument.