### PR TITLE
feat: adapt to inspector v2 results

### DIFF
--- a/cli/cage/audit/scanner.go
+++ b/cli/cage/audit/scanner.go
@@ -112,13 +112,13 @@ func findingToCVE(finding ecrtypes.ImageScanFinding) CVE {
 }
 
 func enhancedFindingToCVE(finding ecrtypes.EnhancedImageScanFinding) CVE {
-	analysis := &EnchancedAnalysis{Score: finding.Score}
+	analysis := &EnhancedAnalysis{Score: finding.Score}
 	cve := CVE{
-		Name:              "unknown",
-		PackageName:       "unknown",
-		PackageVersion:    "unknown",
-		Severity:          ecrtypes.FindingSeverityUndefined,
-		EnchancedAnalysis: analysis,
+		Name:             "unknown",
+		PackageName:      "unknown",
+		PackageVersion:   "unknown",
+		Severity:         ecrtypes.FindingSeverityUndefined,
+		EnhancedAnalysis: analysis,
 	}
 	if finding.Description != nil {
 		cve.Description = *finding.Description

--- a/cli/cage/audit/scanner.go
+++ b/cli/cage/audit/scanner.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	smithy "github.com/aws/smithy-go"
 	"github.com/loilo-inc/canarycage/v5/awsiface"
 )
@@ -55,11 +57,7 @@ func scanImage(ctx context.Context, ecrTool EcrTool, info ImageInfo) ScanResult 
 	} else if findings, err := ecrTool.GetImageScanFindings(ctx, &info, imageID); err != nil {
 		return ScanResult{ImageInfo: info, Err: parseError(err)}
 	} else {
-		var cves []CVE
-		for _, f := range findings.Findings {
-			cve := findingToCVE(f)
-			cves = append(cves, cve)
-		}
+		cves := scanFindingsToCVEs(findings)
 		return ScanResult{ImageInfo: info, Cves: cves}
 	}
 }
@@ -70,4 +68,135 @@ func parseError(err error) error {
 		return ErrScanNotFound
 	}
 	return err
+}
+
+func scanFindingsToCVEs(findings *ecrtypes.ImageScanFindings) []CVE {
+	var cves []CVE
+	if findings.Findings != nil {
+		for _, f := range findings.Findings {
+			cves = append(cves, findingToCVE(f))
+		}
+		return cves
+	} else if findings.EnhancedFindings != nil {
+		for _, f := range findings.EnhancedFindings {
+			cves = append(cves, enhancedFindingToCVE(f))
+		}
+	}
+	return cves
+}
+
+func findingToCVE(finding ecrtypes.ImageScanFinding) CVE {
+	cve := CVE{
+		Name:           "unknown",
+		PackageName:    "unknown",
+		PackageVersion: "unknown",
+		Severity:       finding.Severity,
+	}
+	if finding.Name != nil {
+		cve.Name = *finding.Name
+	}
+	attrs := unwrapAttributes(finding.Attributes)
+	if val, ok := attrs["package_name"]; ok {
+		cve.PackageName = val
+	}
+	if val, ok := attrs["package_version"]; ok {
+		cve.PackageVersion = val
+	}
+	if finding.Uri != nil {
+		cve.Uri = *finding.Uri
+	}
+	if finding.Description != nil {
+		cve.Description = *finding.Description
+	}
+	return cve
+}
+
+func enhancedFindingToCVE(finding ecrtypes.EnhancedImageScanFinding) CVE {
+	analysis := &EnchancedAnalysis{Score: finding.Score}
+	cve := CVE{
+		Name:              "unknown",
+		PackageName:       "unknown",
+		PackageVersion:    "unknown",
+		Severity:          ecrtypes.FindingSeverityUndefined,
+		EnchancedAnalysis: analysis,
+	}
+	if finding.Description != nil {
+		cve.Description = *finding.Description
+	}
+	if finding.Severity != nil {
+		cve.Severity = ecrtypes.FindingSeverity(*finding.Severity)
+	}
+	if finding.Status != nil {
+		analysis.Status = *finding.Status
+	}
+	if finding.ExploitAvailable != nil {
+		analysis.ExploitAvailable = *finding.ExploitAvailable
+	}
+	if finding.FixAvailable != nil {
+		analysis.FixAvailable = *finding.FixAvailable
+	}
+	if finding.PackageVulnerabilityDetails == nil {
+		return cve
+	}
+	details := finding.PackageVulnerabilityDetails
+	if details.VulnerabilityId != nil {
+		cve.Name = *details.VulnerabilityId
+	}
+	if cve.Severity == ecrtypes.FindingSeverityUndefined && details.VendorSeverity != nil {
+		cve.Severity = ecrtypes.FindingSeverity(*details.VendorSeverity)
+	}
+	if details.SourceUrl != nil {
+		cve.Uri = *details.SourceUrl
+	} else if len(details.ReferenceUrls) > 0 {
+		cve.Uri = details.ReferenceUrls[0]
+	}
+	cve.PackageName, cve.PackageVersion = vulnerablePackagesToNameVersion(details.VulnerablePackages)
+	analysis.FixedInVersion = strings.Join(uniquePackageValues(details.VulnerablePackages, func(pkg ecrtypes.VulnerablePackage) *string {
+		return pkg.FixedInVersion
+	}), ", ")
+	return cve
+}
+
+func unwrapAttributes(attrs []ecrtypes.Attribute) map[string]string {
+	m := make(map[string]string)
+	for _, attr := range attrs {
+		if attr.Key != nil && attr.Value != nil {
+			m[*attr.Key] = *attr.Value
+		}
+	}
+	return m
+}
+
+func vulnerablePackagesToNameVersion(packages []ecrtypes.VulnerablePackage) (string, string) {
+	names := uniquePackageValues(packages, func(pkg ecrtypes.VulnerablePackage) *string {
+		return pkg.Name
+	})
+	versions := uniquePackageValues(packages, func(pkg ecrtypes.VulnerablePackage) *string {
+		return pkg.Version
+	})
+	return joinOrUnknown(names), joinOrUnknown(versions)
+}
+
+func uniquePackageValues(packages []ecrtypes.VulnerablePackage, value func(ecrtypes.VulnerablePackage) *string) []string {
+	seen := make(map[string]struct{})
+	var values []string
+	for _, pkg := range packages {
+		v := value(pkg)
+		if v == nil || *v == "" {
+			continue
+		}
+		if _, ok := seen[*v]; ok {
+			continue
+		}
+		seen[*v] = struct{}{}
+		values = append(values, *v)
+	}
+	return values
+}
+
+func joinOrUnknown(values []string) string {
+	if len(values) == 0 {
+		return "unknown"
+	}
+	return strings.Join(values, ", ")
 }

--- a/cli/cage/audit/scanner.go
+++ b/cli/cage/audit/scanner.go
@@ -72,12 +72,11 @@ func parseError(err error) error {
 
 func scanFindingsToCVEs(findings *ecrtypes.ImageScanFindings) []CVE {
 	var cves []CVE
-	if findings.Findings != nil {
+	if len(findings.Findings) > 0 {
 		for _, f := range findings.Findings {
 			cves = append(cves, findingToCVE(f))
 		}
-		return cves
-	} else if findings.EnhancedFindings != nil {
+	} else if len(findings.EnhancedFindings) > 0 {
 		for _, f := range findings.EnhancedFindings {
 			cves = append(cves, enhancedFindingToCVE(f))
 		}

--- a/cli/cage/audit/scanner_test.go
+++ b/cli/cage/audit/scanner_test.go
@@ -152,6 +152,62 @@ func TestScanImage(t *testing.T) {
 		assert.Len(t, result.Cves, 1)
 	})
 
+	t.Run("returns scan result with CVEs from enhanced findings", func(t *testing.T) {
+		imageID := &ecrtypes.ImageIdentifier{
+			ImageTag: aws.String("test-tag"),
+		}
+		findings := &ecrtypes.ImageScanFindings{
+			Findings: nil,
+			EnhancedFindings: []ecrtypes.EnhancedImageScanFinding{
+				{
+					Description:      aws.String("Enhanced vulnerability"),
+					Severity:         aws.String(string(ecrtypes.FindingSeverityHigh)),
+					Status:           aws.String("ACTIVE"),
+					ExploitAvailable: aws.String("NO"),
+					FixAvailable:     aws.String("YES"),
+					Score:            7.5,
+					PackageVulnerabilityDetails: &ecrtypes.PackageVulnerabilityDetails{
+						SourceUrl:       aws.String("https://example.com/CVE-2026-1234"),
+						VulnerabilityId: aws.String("CVE-2026-1234"),
+						VulnerablePackages: []ecrtypes.VulnerablePackage{
+							{
+								Name:           aws.String("openssl"),
+								Version:        aws.String("1.0.0"),
+								FixedInVersion: aws.String("1.0.1"),
+							},
+						},
+					},
+				},
+			},
+		}
+		stub := &stubEcrTool{
+			imageID:  imageID,
+			findings: findings,
+		}
+
+		result := scanImage(ctx, stub, imageInfo)
+
+		assert.NoError(t, result.Err)
+		assert.Equal(t, imageInfo, result.ImageInfo)
+		assert.Equal(t, []CVE{
+			{
+				Name:           "CVE-2026-1234",
+				Description:    "Enhanced vulnerability",
+				PackageName:    "openssl",
+				PackageVersion: "1.0.0",
+				Uri:            "https://example.com/CVE-2026-1234",
+				Severity:       ecrtypes.FindingSeverityHigh,
+				EnchancedAnalysis: &EnchancedAnalysis{
+					Status:           "ACTIVE",
+					ExploitAvailable: "NO",
+					FixAvailable:     "YES",
+					FixedInVersion:   "1.0.1",
+					Score:            7.5,
+				},
+			},
+		}, result.Cves)
+	})
+
 	t.Run("returns error when GetActualImageIdentifier fails", func(t *testing.T) {
 		expectedErr := errors.New("image identifier error")
 		stub := &stubEcrTool{

--- a/cli/cage/audit/scanner_test.go
+++ b/cli/cage/audit/scanner_test.go
@@ -197,7 +197,7 @@ func TestScanImage(t *testing.T) {
 				PackageVersion: "1.0.0",
 				Uri:            "https://example.com/CVE-2026-1234",
 				Severity:       ecrtypes.FindingSeverityHigh,
-				EnchancedAnalysis: &EnchancedAnalysis{
+				EnhancedAnalysis: &EnhancedAnalysis{
 					Status:           "ACTIVE",
 					ExploitAvailable: "NO",
 					FixAvailable:     "YES",
@@ -277,6 +277,71 @@ func TestScanImage(t *testing.T) {
 		assert.Empty(t, result.Cves)
 	})
 }
+func TestEnhancedFindingToCVE(t *testing.T) {
+	t.Run("nil PackageVulnerabilityDetails leaves defaults and skips package fields", func(t *testing.T) {
+		got := enhancedFindingToCVE(ecrtypes.EnhancedImageScanFinding{
+			Severity: aws.String(string(ecrtypes.FindingSeverityHigh)),
+			Score:    4.2,
+		})
+		assert.Equal(t, CVE{
+			Name:           "unknown",
+			PackageName:    "unknown",
+			PackageVersion: "unknown",
+			Severity:       ecrtypes.FindingSeverityHigh,
+			EnhancedAnalysis: &EnhancedAnalysis{
+				Score: 4.2,
+			},
+		}, got)
+	})
+
+	t.Run("falls back to VendorSeverity when top-level severity is missing", func(t *testing.T) {
+		got := enhancedFindingToCVE(ecrtypes.EnhancedImageScanFinding{
+			PackageVulnerabilityDetails: &ecrtypes.PackageVulnerabilityDetails{
+				VulnerabilityId: aws.String("CVE-VENDOR"),
+				VendorSeverity:  aws.String(string(ecrtypes.FindingSeverityMedium)),
+			},
+		})
+		assert.Equal(t, ecrtypes.FindingSeverityMedium, got.Severity)
+		assert.Equal(t, "CVE-VENDOR", got.Name)
+	})
+
+	t.Run("falls back to first ReferenceUrl when SourceUrl is missing", func(t *testing.T) {
+		got := enhancedFindingToCVE(ecrtypes.EnhancedImageScanFinding{
+			PackageVulnerabilityDetails: &ecrtypes.PackageVulnerabilityDetails{
+				ReferenceUrls: []string{"https://ref.example/a", "https://ref.example/b"},
+			},
+		})
+		assert.Equal(t, "https://ref.example/a", got.Uri)
+	})
+
+	t.Run("uniquePackageValues skips nil/empty and dedupes", func(t *testing.T) {
+		got := enhancedFindingToCVE(ecrtypes.EnhancedImageScanFinding{
+			PackageVulnerabilityDetails: &ecrtypes.PackageVulnerabilityDetails{
+				VulnerablePackages: []ecrtypes.VulnerablePackage{
+					{Name: aws.String("openssl"), Version: aws.String("1.0.0"), FixedInVersion: aws.String("1.0.1")},
+					{Name: nil, Version: aws.String(""), FixedInVersion: nil},
+					{Name: aws.String("openssl"), Version: aws.String("1.0.0"), FixedInVersion: aws.String("1.0.1")},
+					{Name: aws.String("curl"), Version: aws.String("8.0"), FixedInVersion: aws.String("")},
+				},
+			},
+		})
+		assert.Equal(t, "openssl, curl", got.PackageName)
+		assert.Equal(t, "1.0.0, 8.0", got.PackageVersion)
+		assert.Equal(t, "1.0.1", got.EnhancedAnalysis.FixedInVersion)
+	})
+
+	t.Run("returns 'unknown' for missing package fields when VulnerablePackages is empty", func(t *testing.T) {
+		got := enhancedFindingToCVE(ecrtypes.EnhancedImageScanFinding{
+			PackageVulnerabilityDetails: &ecrtypes.PackageVulnerabilityDetails{
+				VulnerabilityId: aws.String("CVE-EMPTY"),
+			},
+		})
+		assert.Equal(t, "unknown", got.PackageName)
+		assert.Equal(t, "unknown", got.PackageVersion)
+		assert.Empty(t, got.EnhancedAnalysis.FixedInVersion)
+	})
+}
+
 func TestParseError(t *testing.T) {
 	t.Run("returns ErrScanNotFound when error code is ScanNotFoundException", func(t *testing.T) {
 		scanErr := &smithy.GenericAPIError{

--- a/cli/cage/audit/scanner_test.go
+++ b/cli/cage/audit/scanner_test.go
@@ -152,62 +152,6 @@ func TestScanImage(t *testing.T) {
 		assert.Len(t, result.Cves, 1)
 	})
 
-	t.Run("returns scan result with CVEs from enhanced findings", func(t *testing.T) {
-		imageID := &ecrtypes.ImageIdentifier{
-			ImageTag: aws.String("test-tag"),
-		}
-		findings := &ecrtypes.ImageScanFindings{
-			Findings: nil,
-			EnhancedFindings: []ecrtypes.EnhancedImageScanFinding{
-				{
-					Description:      aws.String("Enhanced vulnerability"),
-					Severity:         aws.String(string(ecrtypes.FindingSeverityHigh)),
-					Status:           aws.String("ACTIVE"),
-					ExploitAvailable: aws.String("NO"),
-					FixAvailable:     aws.String("YES"),
-					Score:            7.5,
-					PackageVulnerabilityDetails: &ecrtypes.PackageVulnerabilityDetails{
-						SourceUrl:       aws.String("https://example.com/CVE-2026-1234"),
-						VulnerabilityId: aws.String("CVE-2026-1234"),
-						VulnerablePackages: []ecrtypes.VulnerablePackage{
-							{
-								Name:           aws.String("openssl"),
-								Version:        aws.String("1.0.0"),
-								FixedInVersion: aws.String("1.0.1"),
-							},
-						},
-					},
-				},
-			},
-		}
-		stub := &stubEcrTool{
-			imageID:  imageID,
-			findings: findings,
-		}
-
-		result := scanImage(ctx, stub, imageInfo)
-
-		assert.NoError(t, result.Err)
-		assert.Equal(t, imageInfo, result.ImageInfo)
-		assert.Equal(t, []CVE{
-			{
-				Name:           "CVE-2026-1234",
-				Description:    "Enhanced vulnerability",
-				PackageName:    "openssl",
-				PackageVersion: "1.0.0",
-				Uri:            "https://example.com/CVE-2026-1234",
-				Severity:       ecrtypes.FindingSeverityHigh,
-				EnhancedAnalysis: &EnhancedAnalysis{
-					Status:           "ACTIVE",
-					ExploitAvailable: "NO",
-					FixAvailable:     "YES",
-					FixedInVersion:   "1.0.1",
-					Score:            7.5,
-				},
-			},
-		}, result.Cves)
-	})
-
 	t.Run("returns error when GetActualImageIdentifier fails", func(t *testing.T) {
 		expectedErr := errors.New("image identifier error")
 		stub := &stubEcrTool{
@@ -277,7 +221,78 @@ func TestScanImage(t *testing.T) {
 		assert.Empty(t, result.Cves)
 	})
 }
+func TestScanFindingsToCVEs(t *testing.T) {
+	t.Run("uses basic Findings when present", func(t *testing.T) {
+		cves := scanFindingsToCVEs(&ecrtypes.ImageScanFindings{
+			Findings: []ecrtypes.ImageScanFinding{
+				{Name: aws.String("CVE-BASIC"), Severity: ecrtypes.FindingSeverityHigh},
+			},
+		})
+		assert.Len(t, cves, 1)
+		assert.Equal(t, "CVE-BASIC", cves[0].Name)
+		assert.Nil(t, cves[0].EnhancedAnalysis)
+	})
+
+	t.Run("uses EnhancedFindings when basic Findings is nil", func(t *testing.T) {
+		cves := scanFindingsToCVEs(&ecrtypes.ImageScanFindings{
+			EnhancedFindings: []ecrtypes.EnhancedImageScanFinding{
+				{
+					Severity: aws.String(string(ecrtypes.FindingSeverityMedium)),
+					PackageVulnerabilityDetails: &ecrtypes.PackageVulnerabilityDetails{
+						VulnerabilityId: aws.String("CVE-ENHANCED"),
+					},
+				},
+			},
+		})
+		assert.Len(t, cves, 1)
+		assert.Equal(t, "CVE-ENHANCED", cves[0].Name)
+		assert.NotNil(t, cves[0].EnhancedAnalysis)
+	})
+
+	t.Run("returns nil when neither Findings nor EnhancedFindings is set", func(t *testing.T) {
+		cves := scanFindingsToCVEs(&ecrtypes.ImageScanFindings{})
+		assert.Nil(t, cves)
+	})
+}
+
 func TestEnhancedFindingToCVE(t *testing.T) {
+	t.Run("populates all fields from a fully-specified finding", func(t *testing.T) {
+		got := enhancedFindingToCVE(ecrtypes.EnhancedImageScanFinding{
+			Description:      aws.String("Enhanced vulnerability"),
+			Severity:         aws.String(string(ecrtypes.FindingSeverityHigh)),
+			Status:           aws.String("ACTIVE"),
+			ExploitAvailable: aws.String("NO"),
+			FixAvailable:     aws.String("YES"),
+			Score:            7.5,
+			PackageVulnerabilityDetails: &ecrtypes.PackageVulnerabilityDetails{
+				SourceUrl:       aws.String("https://example.com/CVE-2026-1234"),
+				VulnerabilityId: aws.String("CVE-2026-1234"),
+				VulnerablePackages: []ecrtypes.VulnerablePackage{
+					{
+						Name:           aws.String("openssl"),
+						Version:        aws.String("1.0.0"),
+						FixedInVersion: aws.String("1.0.1"),
+					},
+				},
+			},
+		})
+		assert.Equal(t, CVE{
+			Name:           "CVE-2026-1234",
+			Description:    "Enhanced vulnerability",
+			PackageName:    "openssl",
+			PackageVersion: "1.0.0",
+			Uri:            "https://example.com/CVE-2026-1234",
+			Severity:       ecrtypes.FindingSeverityHigh,
+			EnhancedAnalysis: &EnhancedAnalysis{
+				Status:           "ACTIVE",
+				ExploitAvailable: "NO",
+				FixAvailable:     "YES",
+				FixedInVersion:   "1.0.1",
+				Score:            7.5,
+			},
+		}, got)
+	})
+
 	t.Run("nil PackageVulnerabilityDetails leaves defaults and skips package fields", func(t *testing.T) {
 		got := enhancedFindingToCVE(ecrtypes.EnhancedImageScanFinding{
 			Severity: aws.String(string(ecrtypes.FindingSeverityHigh)),

--- a/cli/cage/audit/types.go
+++ b/cli/cage/audit/types.go
@@ -93,42 +93,6 @@ type ScanResultSummary struct {
 	ImageURI      string     `json:"image_uri"`
 }
 
-func unwrapAttributes(attrs []ecrtypes.Attribute) map[string]string {
-	m := make(map[string]string)
-	for _, attr := range attrs {
-		if attr.Key != nil && attr.Value != nil {
-			m[*attr.Key] = *attr.Value
-		}
-	}
-	return m
-}
-
-func findingToCVE(finding ecrtypes.ImageScanFinding) CVE {
-	cve := CVE{
-		Name:           "unknown",
-		PackageName:    "unknown",
-		PackageVersion: "unknown",
-		Severity:       finding.Severity,
-	}
-	if finding.Name != nil {
-		cve.Name = *finding.Name
-	}
-	attrs := unwrapAttributes(finding.Attributes)
-	if val, ok := attrs["package_name"]; ok {
-		cve.PackageName = val
-	}
-	if val, ok := attrs["package_version"]; ok {
-		cve.PackageVersion = val
-	}
-	if finding.Uri != nil {
-		cve.Uri = *finding.Uri
-	}
-	if finding.Description != nil {
-		cve.Description = *finding.Description
-	}
-	return cve
-}
-
 type FinalResult struct {
 	Target
 	Result
@@ -152,12 +116,22 @@ type Vuln struct {
 }
 
 type CVE struct {
-	Name           string                   `json:"name"`
-	Description    string                   `json:"description"`
-	PackageName    string                   `json:"package_name"`
-	PackageVersion string                   `json:"package_version"`
-	Uri            string                   `json:"uri"`
-	Severity       ecrtypes.FindingSeverity `json:"severity"`
+	Name              string                   `json:"name"`
+	Description       string                   `json:"description"`
+	PackageName       string                   `json:"package_name"`
+	PackageVersion    string                   `json:"package_version"`
+	Uri               string                   `json:"uri"`
+	Severity          ecrtypes.FindingSeverity `json:"severity"`
+	EnchancedAnalysis *EnchancedAnalysis       `json:"enchanced_analysis"`
+}
+
+type EnchancedAnalysis struct {
+	// Fields below are populated only from EnhancedImageScanFinding (Inspector v2).
+	Status           string  `json:"status"`
+	ExploitAvailable string  `json:"exploit_available"`
+	FixAvailable     string  `json:"fix_available"`
+	FixedInVersion   string  `json:"fixed_in_version"`
+	Score            float64 `json:"score"`
 }
 
 func (a *Result) CriticalCves() []Vuln {

--- a/cli/cage/audit/types.go
+++ b/cli/cage/audit/types.go
@@ -116,16 +116,16 @@ type Vuln struct {
 }
 
 type CVE struct {
-	Name              string                   `json:"name"`
-	Description       string                   `json:"description"`
-	PackageName       string                   `json:"package_name"`
-	PackageVersion    string                   `json:"package_version"`
-	Uri               string                   `json:"uri"`
-	Severity          ecrtypes.FindingSeverity `json:"severity"`
-	EnchancedAnalysis *EnchancedAnalysis       `json:"enchanced_analysis"`
+	Name             string                   `json:"name"`
+	Description      string                   `json:"description"`
+	PackageName      string                   `json:"package_name"`
+	PackageVersion   string                   `json:"package_version"`
+	Uri              string                   `json:"uri"`
+	Severity         ecrtypes.FindingSeverity `json:"severity"`
+	EnhancedAnalysis *EnhancedAnalysis        `json:"enhanced_analysis"`
 }
 
-type EnchancedAnalysis struct {
+type EnhancedAnalysis struct {
 	// Fields below are populated only from EnhancedImageScanFinding (Inspector v2).
 	Status           string  `json:"status"`
 	ExploitAvailable string  `json:"exploit_available"`


### PR DESCRIPTION
- Made a patch to check `findings.EnhancedFindings` when reading scan results.
- `CVE.EnhancedAnalysis` is an optional field which is filled if response was generated by Enhanced Scan.