### PR TITLE
fix(env): restrict envar expansion to inside only string literal

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -44,6 +44,10 @@ const TaskHealthCheckTimeout = "CAGE_TASK_HEALTH_CHECK_TIMEOUT"
 const TaskStoppedTimeout = "CAGE_TASK_STOPPED_TIMEOUT"
 const ServiceStableTimeout = "CAGE_SERVICE_STABLE_TIMEOUT"
 
+var (
+	envarLiteralRegexp = regexp.MustCompile(`\$\{([^}]+)\}`)
+)
+
 func EnsureEnvars(
 	dest *Envars,
 ) error {
@@ -113,8 +117,8 @@ func MergeEnvars(dest *Envars, src *Envars) {
 	}
 }
 
-func ReadAndUnmarshalJson(path string, dest interface{}) error {
-	if d, err := ReadFileAndApplyEnvars(path); err != nil {
+func ReadAndUnmarshalJson(path string, dest any) error {
+	if d, err := readJSONFileAndApplyEnvars(path); err != nil {
 		return err
 	} else if err := json.Unmarshal(d, dest); err != nil {
 		return err
@@ -127,15 +131,89 @@ func ReadFileAndApplyEnvars(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	str := string(d)
-	reg := regexp.MustCompile(`\${(.+?)}`)
-	submatches := reg.FindAllStringSubmatch(str, -1)
-	for _, m := range submatches {
-		if envar, ok := os.LookupEnv(m[1]); ok {
-			str = strings.Replace(str, m[0], envar, -1)
-		} else {
-			return nil, fmt.Errorf("envar literal '%s' found in %s but was not defined", m[0], path)
-		}
+	if strings.EqualFold(filepath.Ext(path), ".json") {
+		return applyEnvarsToJSON(d, path)
+	}
+	str, err := applyEnvarsToString(string(d), path)
+	if err != nil {
+		return nil, err
 	}
 	return []byte(str), nil
+}
+
+func readJSONFileAndApplyEnvars(path string) ([]byte, error) {
+	d, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return applyEnvarsToJSON(d, path)
+}
+
+func applyEnvarsToJSON(d []byte, path string) ([]byte, error) {
+	var js any
+	if err := json.Unmarshal(d, &js); err != nil {
+		return nil, err
+	}
+	applied, err := applyEnvarsToJSONValue(js, path)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(applied)
+}
+
+func applyEnvarsToJSONValue(value any, path string) (any, error) {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			if envarLiteralRegexp.MatchString(key) {
+				return nil, fmt.Errorf("envar literal found in JSON object key '%s' in %s; envars can only be used in JSON string values", key, path)
+			}
+			applied, err := applyEnvarsToJSONValue(child, path)
+			if err != nil {
+				return nil, err
+			}
+			v[key] = applied
+		}
+		return v, nil
+	case []any:
+		for i, child := range v {
+			applied, err := applyEnvarsToJSONValue(child, path)
+			if err != nil {
+				return nil, err
+			}
+			v[i] = applied
+		}
+		return v, nil
+	case string:
+		return applyEnvarsToString(v, path)
+	default:
+		return v, nil
+	}
+}
+
+func applyEnvarsToString(str string, path string) (string, error) {
+	var replaceErr error
+	replaced := envarLiteralRegexp.ReplaceAllStringFunc(str, func(literal string) string {
+		if replaceErr != nil {
+			return literal
+		}
+		envar, err := lookupEnvar(literal, path)
+		if err != nil {
+			replaceErr = err
+			return literal
+		}
+		return envar
+	})
+	return replaced, replaceErr
+}
+
+func lookupEnvar(literal string, path string) (string, error) {
+	match := envarLiteralRegexp.FindStringSubmatch(literal)
+	if len(match) != 2 {
+		return "", fmt.Errorf("invalid envar literal '%s' found in %s", literal, path)
+	}
+	if envar, ok := os.LookupEnv(match[1]); ok {
+		return envar, nil
+	}
+	return "", fmt.Errorf("envar literal '%s' found in %s but was not defined", literal, path)
 }

--- a/env/env.go
+++ b/env/env.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 )
@@ -45,7 +44,7 @@ const TaskStoppedTimeout = "CAGE_TASK_STOPPED_TIMEOUT"
 const ServiceStableTimeout = "CAGE_SERVICE_STABLE_TIMEOUT"
 
 var (
-	envarLiteralRegexp = regexp.MustCompile(`\$\{([^}]+)\}`)
+	envarLiteralRegexp = regexp.MustCompile(`\$\{([^}\r\n]+)\}`)
 )
 
 func EnsureEnvars(
@@ -74,7 +73,7 @@ func LoadServiceDefinition(dir string) (*ecs.CreateServiceInput, error) {
 	if noSvc != nil {
 		return nil, fmt.Errorf("no 'service.json' found in %s", dir)
 	}
-	if err := ReadAndUnmarshalJson(svcPath, &service); err != nil {
+	if err := readAndUnmarshalJson(svcPath, &service); err != nil {
 		return nil, fmt.Errorf("failed to read and unmarshal 'service.json': %s", err)
 	}
 	return &service, nil
@@ -87,7 +86,7 @@ func LoadTaskDefinition(dir string) (*ecs.RegisterTaskDefinitionInput, error) {
 	if noTd != nil {
 		return nil, fmt.Errorf("no 'task-definition.json' found in %s", dir)
 	}
-	if err := ReadAndUnmarshalJson(tdPath, &td); err != nil {
+	if err := readAndUnmarshalJson(tdPath, &td); err != nil {
 		return nil, fmt.Errorf("failed to read and unmarshal 'task-definition.json': %s", err)
 	}
 	return &td, nil
@@ -117,36 +116,15 @@ func MergeEnvars(dest *Envars, src *Envars) {
 	}
 }
 
-func ReadAndUnmarshalJson(path string, dest any) error {
-	if d, err := readJSONFileAndApplyEnvars(path); err != nil {
+func readAndUnmarshalJson(path string, dest any) error {
+	if b, err := os.ReadFile(path); err != nil {
+		return err
+	} else if d, err := applyEnvarsToJSON(b, path); err != nil {
 		return err
 	} else if err := json.Unmarshal(d, dest); err != nil {
 		return err
 	}
 	return nil
-}
-
-func ReadFileAndApplyEnvars(path string) ([]byte, error) {
-	d, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	if strings.EqualFold(filepath.Ext(path), ".json") {
-		return applyEnvarsToJSON(d, path)
-	}
-	str, err := applyEnvarsToString(string(d), path)
-	if err != nil {
-		return nil, err
-	}
-	return []byte(str), nil
-}
-
-func readJSONFileAndApplyEnvars(path string) ([]byte, error) {
-	d, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return applyEnvarsToJSON(d, path)
 }
 
 func applyEnvarsToJSON(d []byte, path string) ([]byte, error) {

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -1,4 +1,4 @@
-package env_test
+package env
 
 import (
 	"os"
@@ -6,64 +6,63 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
-	"github.com/loilo-inc/canarycage/v5/env"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEnsureEnvars(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		e := &env.Envars{
+		e := &Envars{
 			Region:              "us-west-2",
 			Cluster:             "cluster",
 			Service:             "service-next",
 			TaskDefinitionInput: &ecs.RegisterTaskDefinitionInput{},
 		}
-		if err := env.EnsureEnvars(e); err != nil {
+		if err := EnsureEnvars(e); err != nil {
 			t.Fatal(err.Error())
 		}
 	})
 	t.Run("with td arn", func(t *testing.T) {
-		e := &env.Envars{
+		e := &Envars{
 			Region:            "us-west-2",
 			Cluster:           "cluster",
 			Service:           "next",
 			TaskDefinitionArn: "arn://aaa",
 		}
-		if err := env.EnsureEnvars(e); err != nil {
+		if err := EnsureEnvars(e); err != nil {
 			t.Fatal(err.Error())
 		}
 	})
 	t.Run("should return err if nor taskDefinitionArn neither TaskDefinitionInput is defined", func(t *testing.T) {
-		e := &env.Envars{
+		e := &Envars{
 			Region:  "us-west-2",
 			Cluster: "cluster",
 			Service: "next",
 		}
-		err := env.EnsureEnvars(e)
+		err := EnsureEnvars(e)
 		assert.Errorf(t, err, "--nextTaskDefinitionArn or deploy context must be provided")
 	})
 	t.Run("should return err if required props are not defined", func(t *testing.T) {
 		dummy := "aaa"
 		arr := []string{
-			env.RegionKey,
-			env.ServiceKey,
-			env.ClusterKey,
+			RegionKey,
+			ServiceKey,
+			ClusterKey,
 		}
 		for i, v := range arr {
 			m := make(map[string]string)
-			m[env.ServiceKey] = dummy
-			m[env.TaskDefinitionArnKey] = dummy
-			m[env.ClusterKey] = dummy
+			m[ServiceKey] = dummy
+			m[TaskDefinitionArnKey] = dummy
+			m[ClusterKey] = dummy
 			for j, u := range arr {
 				if i == j {
 					m[u] = ""
 				}
 			}
-			e := &env.Envars{
-				Service: m[env.ServiceKey],
-				Cluster: m[env.ClusterKey],
+			e := &Envars{
+				Service: m[ServiceKey],
+				Cluster: m[ClusterKey],
 			}
-			err := env.EnsureEnvars(e)
+			err := EnsureEnvars(e)
 			if err == nil {
 				t.Fatalf("should return error if %s is not defined", v)
 			}
@@ -72,70 +71,136 @@ func TestEnsureEnvars(t *testing.T) {
 }
 
 func TestMergeEnvars(t *testing.T) {
-	e1 := &env.Envars{
+	e1 := &Envars{
 		Region:  "us-west-2",
 		Cluster: "cluster",
 	}
-	e2 := &env.Envars{
+	e2 := &Envars{
 		Cluster: "hoge",
 		Service: "fuga",
 	}
-	env.MergeEnvars(e1, e2)
+	MergeEnvars(e1, e2)
 	assert.Equal(t, e1.Region, "us-west-2")
 	assert.Equal(t, e1.Cluster, "hoge")
 	assert.Equal(t, e1.Service, "fuga")
 }
 
+func TestApplyEnvarsToString(t *testing.T) {
+	const path = "task-definition.json"
+
+	t.Run("replaces envar literals", func(t *testing.T) {
+		t.Setenv("IMAGE_REPOSITORY", "repo/app")
+		t.Setenv("IMAGE_TAG", "v1.2.3")
+
+		got, err := applyEnvarsToString("${IMAGE_REPOSITORY}:${IMAGE_TAG}", path)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "repo/app:v1.2.3", got)
+	})
+
+	t.Run("keeps string without envar literals", func(t *testing.T) {
+		got, err := applyEnvarsToString("repo/app:latest", path)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "repo/app:latest", got)
+	})
+
+	t.Run("returns error if envar is not defined", func(t *testing.T) {
+		unsetenv(t, "UNDEFINED_IMAGE_TAG")
+
+		got, err := applyEnvarsToString("repo/app:${UNDEFINED_IMAGE_TAG}", path)
+
+		assert.Equal(t, "repo/app:${UNDEFINED_IMAGE_TAG}", got)
+		assert.EqualError(t, err, "envar literal '${UNDEFINED_IMAGE_TAG}' found in task-definition.json but was not defined")
+	})
+}
+
+func TestLookupEnvar(t *testing.T) {
+	const path = "service.json"
+
+	t.Run("returns defined envar", func(t *testing.T) {
+		t.Setenv("SERVICE_NAME", "canary-service")
+
+		got, err := lookupEnvar("${SERVICE_NAME}", path)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "canary-service", got)
+	})
+
+	t.Run("returns empty string for defined empty envar", func(t *testing.T) {
+		t.Setenv("EMPTY_VALUE", "")
+
+		got, err := lookupEnvar("${EMPTY_VALUE}", path)
+
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns error if literal is invalid", func(t *testing.T) {
+		got, err := lookupEnvar("SERVICE_NAME", path)
+
+		assert.Empty(t, got)
+		assert.EqualError(t, err, "invalid envar literal 'SERVICE_NAME' found in service.json")
+	})
+
+	t.Run("returns error if envar is not defined", func(t *testing.T) {
+		unsetenv(t, "UNDEFINED_SERVICE_NAME")
+
+		got, err := lookupEnvar("${UNDEFINED_SERVICE_NAME}", path)
+
+		assert.Empty(t, got)
+		assert.EqualError(t, err, "envar literal '${UNDEFINED_SERVICE_NAME}' found in service.json but was not defined")
+	})
+}
+
+func unsetenv(t *testing.T, key string) {
+	t.Helper()
+
+	value, ok := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Cleanup(func() {
+		if ok {
+			_ = os.Setenv(key, value)
+		}
+	})
+}
+
 func TestLoadServiceDefinition(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		d, err := env.LoadServiceDefinition("../fixtures")
+		d, err := LoadServiceDefinition("../fixtures")
 		if err != nil {
 			t.Fatal(err.Error())
 		}
 		assert.Equal(t, *d.ServiceName, "service")
 	})
 	t.Run("should error if service.json is not found", func(t *testing.T) {
-		_, err := env.LoadServiceDefinition("./testdata")
+		_, err := LoadServiceDefinition("./testdata")
 		assert.EqualError(t, err, "no 'service.json' found in ./testdata")
 	})
 	t.Run("should error if service.json is invalid", func(t *testing.T) {
-		_, err := env.LoadServiceDefinition("./testdata/invalid")
+		_, err := LoadServiceDefinition("./testdata/invalid")
 		assert.ErrorContains(t, err, "failed to read and unmarshal 'service.json':")
 	})
 }
 
 func TestLoadTaskDefinition(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		d, err := env.LoadTaskDefinition("../fixtures")
+		d, err := LoadTaskDefinition("../fixtures")
 		if err != nil {
 			t.Fatal(err.Error())
 		}
 		assert.Equal(t, *d.Family, "test-task")
 	})
 	t.Run("should error if task-definition.json is not found", func(t *testing.T) {
-		_, err := env.LoadTaskDefinition("./testdata")
+		_, err := LoadTaskDefinition("./testdata")
 		assert.EqualError(t, err, "no 'task-definition.json' found in ./testdata")
 	})
 	t.Run("should error if task-definition.json is invalid", func(t *testing.T) {
-		_, err := env.LoadTaskDefinition("./testdata/invalid")
+		_, err := LoadTaskDefinition("./testdata/invalid")
 		assert.ErrorContains(t, err, "failed to read and unmarshal 'task-definition.json':")
 	})
-}
-
-func TestReadFileAndApplyEnvars(t *testing.T) {
-	t.Setenv("HOGE", "hogehoge")
-	t.Setenv("FUGA", "fugafuga")
-	d, err := env.ReadFileAndApplyEnvars("./testdata/template.txt")
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	s := string(d)
-	e := `HOGE=hogehoge
-FUGA=fugafuga
-fugafuga=hogehoge`
-	if s != e {
-		t.Fatalf("e: %s, a: %s", e, s)
-	}
 }
 
 func TestReadAndUnmarshalJsonEscapesEnvars(t *testing.T) {
@@ -150,7 +215,7 @@ func TestReadAndUnmarshalJsonEscapesEnvars(t *testing.T) {
 		Family      string `json:"family"`
 		TaskRoleArn string `json:"taskRoleArn"`
 	}
-	if err := env.ReadAndUnmarshalJson(path, &got); err != nil {
+	if err := readAndUnmarshalJson(path, &got); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -167,7 +232,7 @@ func TestReadAndUnmarshalJsonRejectsEnvarsInObjectKeys(t *testing.T) {
 	}
 
 	var got map[string]string
-	err := env.ReadAndUnmarshalJson(path, &got)
+	err := readAndUnmarshalJson(path, &got)
 
 	assert.ErrorContains(t, err, "envar literal found in JSON object key '${KEY}'")
 }
@@ -180,7 +245,7 @@ func TestReadAndUnmarshalJsonRejectsEnvarsOutsideStringValues(t *testing.T) {
 	}
 
 	var got map[string]int
-	err := env.ReadAndUnmarshalJson(path, &got)
+	err := readAndUnmarshalJson(path, &got)
 
 	assert.Error(t, err)
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -39,7 +39,7 @@ func TestEnsureEnvars(t *testing.T) {
 			Service: "next",
 		}
 		err := EnsureEnvars(e)
-		assert.Errorf(t, err, "--nextTaskDefinitionArn or deploy context must be provided")
+		assert.EqualError(t, err, "--nextTaskDefinitionArn or deploy context must be provided")
 	})
 	t.Run("should return err if required props are not defined", func(t *testing.T) {
 		dummy := "aaa"

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -2,6 +2,7 @@ package env_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -122,8 +123,8 @@ func TestLoadTaskDefinition(t *testing.T) {
 }
 
 func TestReadFileAndApplyEnvars(t *testing.T) {
-	os.Setenv("HOGE", "hogehoge")
-	os.Setenv("FUGA", "fugafuga")
+	t.Setenv("HOGE", "hogehoge")
+	t.Setenv("FUGA", "fugafuga")
 	d, err := env.ReadFileAndApplyEnvars("./testdata/template.txt")
 	if err != nil {
 		t.Fatal(err.Error())
@@ -135,4 +136,51 @@ fugafuga=hogehoge`
 	if s != e {
 		t.Fatalf("e: %s, a: %s", e, s)
 	}
+}
+
+func TestReadAndUnmarshalJsonEscapesEnvars(t *testing.T) {
+	t.Setenv("IMAGE_TAG", `latest","taskRoleArn":"arn:aws:iam::123456789012:role/pwn","image":"attacker`)
+	path := filepath.Join(t.TempDir(), "task-definition.json")
+	if err := os.WriteFile(path, []byte(`{"image":"repo:${IMAGE_TAG}","family":"app"}`), 0o644); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	var got struct {
+		Image       string `json:"image"`
+		Family      string `json:"family"`
+		TaskRoleArn string `json:"taskRoleArn"`
+	}
+	if err := env.ReadAndUnmarshalJson(path, &got); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	assert.Equal(t, `repo:latest","taskRoleArn":"arn:aws:iam::123456789012:role/pwn","image":"attacker`, got.Image)
+	assert.Equal(t, "app", got.Family)
+	assert.Empty(t, got.TaskRoleArn)
+}
+
+func TestReadAndUnmarshalJsonRejectsEnvarsInObjectKeys(t *testing.T) {
+	t.Setenv("KEY", "image")
+	path := filepath.Join(t.TempDir(), "task-definition.json")
+	if err := os.WriteFile(path, []byte(`{"${KEY}":"value"}`), 0o644); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	var got map[string]string
+	err := env.ReadAndUnmarshalJson(path, &got)
+
+	assert.ErrorContains(t, err, "envar literal found in JSON object key '${KEY}'")
+}
+
+func TestReadAndUnmarshalJsonRejectsEnvarsOutsideStringValues(t *testing.T) {
+	t.Setenv("COUNT", "1")
+	path := filepath.Join(t.TempDir(), "service.json")
+	if err := os.WriteFile(path, []byte(`{"desiredCount":${COUNT}}`), 0o644); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	var got map[string]int
+	err := env.ReadAndUnmarshalJson(path, &got)
+
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Security Validation Summary

`ReadAndUnmarshalJson` no longer performs raw text substitution before JSON parsing. JSON files are parsed first, environment variables are applied only to JSON string values, and the result is serialized back through `json.Marshal`.

This prevents environment variable values from breaking out of a JSON string and injecting additional ECS task/service fields.

## Attack Pattern Prevented

Before the change, this template was unsafe:

```json
{
  "image": "repo:${IMAGE_TAG}",
  "family": "app"
}
```

With this environment value:

```sh
IMAGE_TAG='latest","taskRoleArn":"arn:aws:iam::123456789012:role/pwn","image":"attacker'
```

Raw substitution could create an extra `taskRoleArn` field or override `image`. After the change, the payload remains part of the `image` string and cannot modify JSON structure.

## Patterns No Longer Accepted

Object keys cannot be templated:

```json
{
  "${KEY}": "value"
}
```

Environment variables outside JSON strings are invalid because the file must be valid JSON before expansion:

```json
{
  "desiredCount": ${COUNT}
}
```

Use explicit JSON values instead, or keep templated values inside strings where the target ECS field expects a string.