### PR TITLE
feat(breaking): disabled parameter input from envars.

### DIFF
--- a/cli/cage/cageapp/flags.go
+++ b/cli/cage/cageapp/flags.go
@@ -1,14 +1,12 @@
 package cageapp
 
 import (
-	"github.com/loilo-inc/canarycage/v5/env"
 	"github.com/urfave/cli/v3"
 )
 
 func RegionFlag(dest *string) *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:        "region",
-		Sources:     cli.EnvVars(env.RegionKey),
 		Usage:       "aws region for ecs. if not specified, try to load from aws sessions automatically",
 		Destination: dest,
 		Required:    true,
@@ -17,7 +15,6 @@ func RegionFlag(dest *string) *cli.StringFlag {
 func ClusterFlag(dest *string) *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:        "cluster",
-		Sources:     cli.EnvVars(env.ClusterKey),
 		Usage:       "ecs cluster name. if not specified, load from service.json",
 		Destination: dest,
 	}
@@ -25,7 +22,6 @@ func ClusterFlag(dest *string) *cli.StringFlag {
 func ServiceFlag(dest *string) *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:        "service",
-		Sources:     cli.EnvVars(env.ServiceKey),
 		Usage:       "service name. if not specified, load from service.json",
 		Destination: dest,
 	}
@@ -33,7 +29,6 @@ func ServiceFlag(dest *string) *cli.StringFlag {
 func TaskDefinitionArnFlag(dest *string) *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:        "taskDefinitionArn",
-		Sources:     cli.EnvVars(env.TaskDefinitionArnKey),
 		Usage:       "full arn or family:revision of task definition. if not specified, new task definition will be created based on task-definition.json",
 		Destination: dest,
 	}
@@ -42,7 +37,6 @@ func TaskDefinitionArnFlag(dest *string) *cli.StringFlag {
 func CanaryTaskIdleDurationFlag(dest *int) *cli.IntFlag {
 	return &cli.IntFlag{
 		Name:        "canaryTaskIdleDuration",
-		Sources:     cli.EnvVars(env.CanaryTaskIdleDuration),
 		Usage:       "duration seconds for waiting canary task that isn't attached to target group considered as ready for serving traffic",
 		Destination: dest,
 		Value:       15,
@@ -52,7 +46,6 @@ func CanaryTaskIdleDurationFlag(dest *int) *cli.IntFlag {
 func TaskRunningWaitFlag(dest *int) *cli.IntFlag {
 	return &cli.IntFlag{
 		Name:        "taskRunningTimeout",
-		Sources:     cli.EnvVars(env.TaskRunningTimeout),
 		Usage:       "max duration seconds for waiting canary task running",
 		Destination: dest,
 		Category:    "ADVANCED",
@@ -63,7 +56,6 @@ func TaskRunningWaitFlag(dest *int) *cli.IntFlag {
 func TaskHealthCheckWaitFlag(dest *int) *cli.IntFlag {
 	return &cli.IntFlag{
 		Name:        "taskHealthCheckTimeout",
-		Sources:     cli.EnvVars(env.TaskHealthCheckTimeout),
 		Usage:       "max duration seconds for waiting canary task health check",
 		Destination: dest,
 		Category:    "ADVANCED",
@@ -74,7 +66,6 @@ func TaskHealthCheckWaitFlag(dest *int) *cli.IntFlag {
 func TaskStoppedWaitFlag(dest *int) *cli.IntFlag {
 	return &cli.IntFlag{
 		Name:        "taskStoppedTimeout",
-		Sources:     cli.EnvVars(env.TaskStoppedTimeout),
 		Usage:       "max duration seconds for waiting canary task stopped",
 		Destination: dest,
 		Category:    "ADVANCED",
@@ -85,7 +76,6 @@ func TaskStoppedWaitFlag(dest *int) *cli.IntFlag {
 func ServiceStableWaitFlag(dest *int) *cli.IntFlag {
 	return &cli.IntFlag{
 		Name:        "serviceStableTimeout",
-		Sources:     cli.EnvVars(env.ServiceStableTimeout),
 		Usage:       "max duration seconds for waiting service stable",
 		Destination: dest,
 		Category:    "ADVANCED",

--- a/cli/cage/cageapp/flags.go
+++ b/cli/cage/cageapp/flags.go
@@ -7,7 +7,7 @@ import (
 func RegionFlag(dest *string) *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:        "region",
-		Usage:       "aws region for ecs. if not specified, try to load from aws sessions automatically",
+		Usage:       "aws region to be used. region specified in aws session is always ignored",
 		Destination: dest,
 		Required:    true,
 	}

--- a/cli/cage/cageapp/flags_test.go
+++ b/cli/cage/cageapp/flags_test.go
@@ -148,10 +148,10 @@ func TestFlagDestinations(t *testing.T) {
 // TestFlagDefaultValues verifies default values for int flags
 func TestFlagDefaultValues(t *testing.T) {
 	tests := []struct {
-		name         string
-		flagFunc     func(*int) *cli.IntFlag
-		expectedVal  int
-		expectedCat  string
+		name        string
+		flagFunc    func(*int) *cli.IntFlag
+		expectedVal int
+		expectedCat string
 	}{
 		{
 			name:        "CanaryTaskIdleDurationFlag",

--- a/cli/cage/cageapp/flags_test.go
+++ b/cli/cage/cageapp/flags_test.go
@@ -16,12 +16,6 @@ func TestRegionFlag(t *testing.T) {
 	assert.Equal(t, "aws region for ecs. if not specified, try to load from aws sessions automatically", flag.Usage)
 	assert.True(t, flag.Required)
 	assert.Equal(t, &dest, flag.Destination)
-
-	// Verify Sources contain the correct environment variable
-	sources := flag.Sources
-	assert.NotNil(t, sources)
-	// The Sources field is a ValueSourceChain, so we verify it's set
-	assert.NotNil(t, sources)
 }
 
 func TestClusterFlag(t *testing.T) {
@@ -33,7 +27,6 @@ func TestClusterFlag(t *testing.T) {
 	assert.Equal(t, "ecs cluster name. if not specified, load from service.json", flag.Usage)
 	assert.False(t, flag.Required)
 	assert.Equal(t, &dest, flag.Destination)
-	assert.NotNil(t, flag.Sources)
 }
 
 func TestServiceFlag(t *testing.T) {
@@ -45,7 +38,6 @@ func TestServiceFlag(t *testing.T) {
 	assert.Equal(t, "service name. if not specified, load from service.json", flag.Usage)
 	assert.False(t, flag.Required)
 	assert.Equal(t, &dest, flag.Destination)
-	assert.NotNil(t, flag.Sources)
 }
 
 func TestTaskDefinitionArnFlag(t *testing.T) {
@@ -57,7 +49,6 @@ func TestTaskDefinitionArnFlag(t *testing.T) {
 	assert.Equal(t, "full arn or family:revision of task definition. if not specified, new task definition will be created based on task-definition.json", flag.Usage)
 	assert.False(t, flag.Required)
 	assert.Equal(t, &dest, flag.Destination)
-	assert.NotNil(t, flag.Sources)
 }
 
 func TestCanaryTaskIdleDurationFlag(t *testing.T) {
@@ -69,7 +60,6 @@ func TestCanaryTaskIdleDurationFlag(t *testing.T) {
 	assert.Equal(t, "duration seconds for waiting canary task that isn't attached to target group considered as ready for serving traffic", flag.Usage)
 	assert.Equal(t, 15, flag.Value)
 	assert.Equal(t, &dest, flag.Destination)
-	assert.NotNil(t, flag.Sources)
 }
 
 func TestTaskRunningWaitFlag(t *testing.T) {
@@ -82,7 +72,6 @@ func TestTaskRunningWaitFlag(t *testing.T) {
 	assert.Equal(t, 900, flag.Value)
 	assert.Equal(t, "ADVANCED", flag.Category)
 	assert.Equal(t, &dest, flag.Destination)
-	assert.NotNil(t, flag.Sources)
 }
 
 func TestTaskHealthCheckWaitFlag(t *testing.T) {
@@ -95,7 +84,6 @@ func TestTaskHealthCheckWaitFlag(t *testing.T) {
 	assert.Equal(t, 900, flag.Value)
 	assert.Equal(t, "ADVANCED", flag.Category)
 	assert.Equal(t, &dest, flag.Destination)
-	assert.NotNil(t, flag.Sources)
 }
 
 func TestTaskStoppedWaitFlag(t *testing.T) {
@@ -108,7 +96,6 @@ func TestTaskStoppedWaitFlag(t *testing.T) {
 	assert.Equal(t, 900, flag.Value)
 	assert.Equal(t, "ADVANCED", flag.Category)
 	assert.Equal(t, &dest, flag.Destination)
-	assert.NotNil(t, flag.Sources)
 }
 
 func TestServiceStableWaitFlag(t *testing.T) {
@@ -121,7 +108,6 @@ func TestServiceStableWaitFlag(t *testing.T) {
 	assert.Equal(t, 900, flag.Value)
 	assert.Equal(t, "ADVANCED", flag.Category)
 	assert.Equal(t, &dest, flag.Destination)
-	assert.NotNil(t, flag.Sources)
 }
 
 // TestFlagDestinations verifies that flag destination pointers work correctly

--- a/cli/cage/cageapp/flags_test.go
+++ b/cli/cage/cageapp/flags_test.go
@@ -13,7 +13,7 @@ func TestRegionFlag(t *testing.T) {
 
 	assert.NotNil(t, flag)
 	assert.Equal(t, "region", flag.Name)
-	assert.Equal(t, "aws region for ecs. if not specified, try to load from aws sessions automatically", flag.Usage)
+	assert.Equal(t, "aws region to be used. region specified in aws session is always ignored", flag.Usage)
 	assert.True(t, flag.Required)
 	assert.Equal(t, &dest, flag.Destination)
 }

--- a/cli/cage/commands/command_test.go
+++ b/cli/cage/commands/command_test.go
@@ -124,7 +124,7 @@ func TestSetupCage(t *testing.T) {
 		})
 
 		_, err := cmds.setupCage(input, "../../../fixtures")
-			assert.EqualError(t, err, "--region is required")
+		assert.EqualError(t, err, "--region is required")
 	})
 
 	t.Run("propagates provider error", func(t *testing.T) {

--- a/cli/cage/commands/command_test.go
+++ b/cli/cage/commands/command_test.go
@@ -124,7 +124,7 @@ func TestSetupCage(t *testing.T) {
 		})
 
 		_, err := cmds.setupCage(input, "../../../fixtures")
-		assert.EqualError(t, err, "--region [CAGE_REGION] is required")
+			assert.EqualError(t, err, "--region is required")
 	})
 
 	t.Run("propagates provider error", func(t *testing.T) {

--- a/cli/cage/commands/rollout.go
+++ b/cli/cage/commands/rollout.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/loilo-inc/canarycage/v5/cli/cage/cageapp"
 	"github.com/loilo-inc/canarycage/v5/cli/cage/prompt"
-	"github.com/loilo-inc/canarycage/v5/env"
 	"github.com/loilo-inc/canarycage/v5/types"
 	"github.com/urfave/cli/v3"
 )
@@ -25,13 +24,11 @@ func (c *CageCommands) RollOut(input *cageapp.CageCmdInput) *cli.Command {
 			cageapp.CanaryTaskIdleDurationFlag(&input.CanaryTaskIdleDuration),
 			&cli.StringFlag{
 				Name:        "canaryInstanceArn",
-				Sources:     cli.EnvVars(env.CanaryInstanceArnKey),
 				Usage:       "EC2 instance ARN for placing canary task. required only when LaunchType is EC2",
 				Destination: &input.CanaryInstanceArn,
 			},
 			&cli.BoolFlag{
 				Name:        "updateService",
-				Sources:     cli.EnvVars(env.UpdateServiceKey),
 				Usage:       "Update service configurations except for task definiton. Default is false.",
 				Destination: &updateServiceConf,
 			},

--- a/cli/cage/commands/rollout.go
+++ b/cli/cage/commands/rollout.go
@@ -29,7 +29,7 @@ func (c *CageCommands) RollOut(input *cageapp.CageCmdInput) *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:        "updateService",
-				Usage:       "Update service configurations except for task definiton. Default is false.",
+				Usage:       "Update service configurations except for task definition. Default is false.",
 				Destination: &updateServiceConf,
 			},
 			cageapp.TaskRunningWaitFlag(&input.CanaryTaskRunningWait),

--- a/cli/cage/main.go
+++ b/cli/cage/main.go
@@ -46,11 +46,13 @@ func main() {
 			&cli.BoolFlag{
 				Name:        "ci",
 				Usage:       "CI mode. Skip all confirmations and use default values.",
+				Sources:     cli.EnvVars("CI"),
 				Destination: &appConf.CI,
 			},
 			&cli.BoolFlag{
 				Name:        "no-color",
 				Usage:       "Disable colored output",
+				Sources:     cli.EnvVars("NO_COLOR"),
 				Destination: &appConf.NoColor,
 			},
 		},

--- a/cli/cage/main.go
+++ b/cli/cage/main.go
@@ -46,13 +46,11 @@ func main() {
 			&cli.BoolFlag{
 				Name:        "ci",
 				Usage:       "CI mode. Skip all confirmations and use default values.",
-				Sources:     cli.EnvVars("CI"),
 				Destination: &appConf.CI,
 			},
 			&cli.BoolFlag{
 				Name:        "no-color",
 				Usage:       "Disable colored output",
-				Sources:     cli.EnvVars("NO_COLOR"),
 				Destination: &appConf.NoColor,
 			},
 		},

--- a/env/env.go
+++ b/env/env.go
@@ -26,23 +26,6 @@ type Envars struct {
 	ServiceStableWait         int // sec
 }
 
-// required
-const ClusterKey = "CAGE_CLUSTER"
-const ServiceKey = "CAGE_SERVICE"
-
-// either required
-const TaskDefinitionArnKey = "CAGE_TASK_DEFINITION_ARN"
-
-// optional
-const CanaryInstanceArnKey = "CAGE_CANARY_INSTANCE_ARN"
-const RegionKey = "CAGE_REGION"
-const CanaryTaskIdleDuration = "CAGE_CANARY_TASK_IDLE_DURATION"
-const UpdateServiceKey = "CAGE_UPDATE_SERVIEC"
-const TaskRunningTimeout = "CAGE_TASK_RUNNING_TIMEOUT"
-const TaskHealthCheckTimeout = "CAGE_TASK_HEALTH_CHECK_TIMEOUT"
-const TaskStoppedTimeout = "CAGE_TASK_STOPPED_TIMEOUT"
-const ServiceStableTimeout = "CAGE_SERVICE_STABLE_TIMEOUT"
-
 var (
 	envarLiteralRegexp = regexp.MustCompile(`\$\{([^}\r\n]+)\}`)
 )
@@ -52,13 +35,13 @@ func EnsureEnvars(
 ) error {
 	// required
 	if dest.Region == "" {
-		return fmt.Errorf("--region [%s] is required", RegionKey)
+		return fmt.Errorf("--region is required")
 	}
 	if dest.Cluster == "" {
-		return fmt.Errorf("--cluster [%s] is required", ClusterKey)
+		return fmt.Errorf("--cluster is required")
 	}
 	if dest.Service == "" {
-		return fmt.Errorf("--service [%s] is required", ServiceKey)
+		return fmt.Errorf("--service is required")
 	}
 	if dest.TaskDefinitionArn == "" && dest.TaskDefinitionInput == nil {
 		return fmt.Errorf("--nextTaskDefinitionArn or deploy context must be provided")

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -42,30 +42,44 @@ func TestEnsureEnvars(t *testing.T) {
 		assert.EqualError(t, err, "--nextTaskDefinitionArn or deploy context must be provided")
 	})
 	t.Run("should return err if required props are not defined", func(t *testing.T) {
-		dummy := "aaa"
-		arr := []string{
-			RegionKey,
-			ServiceKey,
-			ClusterKey,
+		tests := []struct {
+			name string
+			e    *Envars
+		}{
+			{
+				name: "missing region",
+				e: &Envars{
+					Region:            "",
+					Service:           "service",
+					Cluster:           "cluster",
+					TaskDefinitionArn: "arn://aaa",
+				},
+			},
+			{
+				name: "missing service",
+				e: &Envars{
+					Region:            "us-west-2",
+					Service:           "",
+					Cluster:           "cluster",
+					TaskDefinitionArn: "arn://aaa",
+				},
+			},
+			{
+				name: "missing cluster",
+				e: &Envars{
+					Region:            "us-west-2",
+					Service:           "service",
+					Cluster:           "",
+					TaskDefinitionArn: "arn://aaa",
+				},
+			},
 		}
-		for i, v := range arr {
-			m := make(map[string]string)
-			m[ServiceKey] = dummy
-			m[TaskDefinitionArnKey] = dummy
-			m[ClusterKey] = dummy
-			for j, u := range arr {
-				if i == j {
-					m[u] = ""
-				}
-			}
-			e := &Envars{
-				Service: m[ServiceKey],
-				Cluster: m[ClusterKey],
-			}
-			err := EnsureEnvars(e)
-			if err == nil {
-				t.Fatalf("should return error if %s is not defined", v)
-			}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := EnsureEnvars(tt.e)
+				assert.Error(t, err)
+			})
 		}
 	})
 }


### PR DESCRIPTION
Disabled parameter-corresponded environment variables for subcommands. This is introduced to prevent implicit envar injection during CI/CD pipeline.

## Disabled Variables

`CAGE_CLUSTER`
`CAGE_SERVICE`
`CAGE_TASK_DEFINITION_ARN`
`CAGE_CANARY_INSTANCE_ARN`
`CAGE_REGION`
`CAGE_CANARY_TASK_IDLE_DURATION`
`CAGE_UPDATE_SERVIEC`
`CAGE_TASK_RUNNING_TIMEOUT`
`CAGE_TASK_HEALTH_CHECK_TIMEOUT`
`CAGE_TASK_STOPPED_TIMEOUT`
`CAGE_SERVICE_STABLE_TIMEOUT`

## Variables not removed

These global options are not removed:

- `CI`
- `NO_COLOR`

## Release Plan

This will be released for cage v6.